### PR TITLE
Revert back to nullable edge in edges list

### DIFF
--- a/graphql/api/domains/agent/util.graphqls
+++ b/graphql/api/domains/agent/util.graphqls
@@ -10,7 +10,7 @@ type AgentEdge {
 
 type AgentEventConnection {
 	pageInfo: PageInfo!
-	edges: [AgentEventEdge!]!
+	edges: [AgentEventEdge]!
 }
 
 type AgentEventEdge {

--- a/graphql/api/domains/detection/util.graphqls
+++ b/graphql/api/domains/detection/util.graphqls
@@ -1,6 +1,6 @@
 type DetectionConnection {
 	pageInfo: PageInfo!
-	edges: [DetectionEdge!]!
+	edges: [DetectionEdge]!
 }
 
 type DetectionEdge {

--- a/graphql/api/domains/geofence/util.graphqls
+++ b/graphql/api/domains/geofence/util.graphqls
@@ -1,6 +1,6 @@
 type GeofenceEventConnection {
 	pageInfo: PageInfo!
-	edges: [GeofenceEventEdge!]!
+	edges: [GeofenceEventEdge]!
 }
 
 type GeofenceEventEdge {

--- a/graphql/api/domains/sensor/util.graphqls
+++ b/graphql/api/domains/sensor/util.graphqls
@@ -1,6 +1,6 @@
 type MeasurementConnection {
 	pageInfo: PageInfo!
-	edges: [MeasurementEdge!]!
+	edges: [MeasurementEdge]!
 }
 
 type MeasurementEdge {

--- a/graphql/api/domains/track/util.graphqls
+++ b/graphql/api/domains/track/util.graphqls
@@ -1,6 +1,6 @@
 type TrackConnection {
 	pageInfo: PageInfo!
-	edges: [TrackEdge!]!
+	edges: [TrackEdge]!
 }
 
 type TrackEdge {

--- a/graphql/api/domains/zone/util.graphqls
+++ b/graphql/api/domains/zone/util.graphqls
@@ -1,6 +1,6 @@
 type ZoneEventConnection {
 	pageInfo: PageInfo!
-	edges: [ZoneEventEdge!]!
+	edges: [ZoneEventEdge]!
 }
 
 type ZoneEventEdge {


### PR DESCRIPTION
The `ConnectionFieldTypeVisitor` class in Spring GraphQL's source code is responsible for iterating through our schema and determining which defined types are "Connection" types that can be mapped to by our custom `ConnectionAdapter`. That class seems to be hardcoded to only mark `GraphQLObjectType` `edges` fields as mappable and not `GraphQLNonNull` type fields (AKA `[Foobar]!` and not `[Foobar!]!`). I've tried looking for ways to override that process or configure it to also accept `GraphQLNonNull` types but the documentation for Spring GraphQL is lacking and I have not had any success.

Therefore I am reverting back to nullable edges for now. However, our implementation should never return a `null` edge.

