### PR TITLE
feat: add eventsSummary query

### DIFF
--- a/graphql/api/domains/summary/query.graphqls
+++ b/graphql/api/domains/summary/query.graphqls
@@ -1,3 +1,4 @@
 extend type Query {
 	tracksSummary(startTime: DateTimeOffset!, endTime: DateTimeOffset!, tags: FilterTagInput, bucket: SummaryBucketSize): TracksSummary
+	eventsSummary(startTime: DateTimeOffset!, endTime: DateTimeOffset!, bucket: SummaryBucketSize): EventsSummary
 }

--- a/graphql/api/domains/summary/summary.graphqls
+++ b/graphql/api/domains/summary/summary.graphqls
@@ -14,3 +14,13 @@ type TracksSummaryBucket {
 	total: Int!
 	counts: [TracksCountByTag!]!
 }
+
+type EventsSummary {
+	total: Int!
+	buckets: [EventsSummaryBucket!]
+}
+
+type EventsSummaryBucket {
+	time: DateTimeOffset!
+	total: Int!
+}


### PR DESCRIPTION
Add events summary query by startTime, endTime, and bucket size.

[CE-2821]

[CE-2821]: https://worlds-io.atlassian.net/browse/CE-2821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ