### PR TITLE
CE-3158: Additional event fields

### DIFF
--- a/graphql/api/domains/events/events.graphqls
+++ b/graphql/api/domains/events/events.graphqls
@@ -38,6 +38,7 @@ type Event {
 	images: [Image!]!
 	videos: [Video!]!
 	properties: EventProperties
+	draft: Boolean
 }
 
 type EventProperties {
@@ -61,6 +62,7 @@ input CreateEventInput {
 	clips: [CreateClipInput!]
 	trackIds: [ID!]
 	properties: EventPropertiesInput
+	draft: Boolean
 }
 
 input UpdateEventInput {
@@ -77,6 +79,7 @@ input UpdateEventInput {
 	clips: [CreateClipInput!]
 	trackIds: [ID!]
 	properties: EventPropertiesInput
+	draft: Boolean
 }
 
 input EventPropertiesInput {

--- a/graphql/api/domains/events/events.graphqls
+++ b/graphql/api/domains/events/events.graphqls
@@ -62,7 +62,7 @@ input CreateEventInput {
 	clips: [CreateClipInput!]
 	trackIds: [ID!]
 	properties: EventPropertiesInput
-	draft: Boolean
+	draft: Boolean! = false
 }
 
 input UpdateEventInput {

--- a/graphql/api/domains/events/events.graphqls
+++ b/graphql/api/domains/events/events.graphqls
@@ -37,6 +37,13 @@ type Event {
 	metadata: JSON
 	images: [Image!]!
 	videos: [Video!]!
+	properties: EventProperties
+}
+
+type EventProperties {
+	sites: [Site!]
+	dataSources: [DataSource!]
+	tags: [Tag!]
 }
 
 input CreateEventInput {
@@ -53,6 +60,7 @@ input CreateEventInput {
 	uploads: [UploadImageInput!]
 	clips: [CreateClipInput!]
 	trackIds: [ID!]
+	properties: EventPropertiesInput
 }
 
 input UpdateEventInput {
@@ -68,4 +76,11 @@ input UpdateEventInput {
 	uploads: [UploadImageInput!]
 	clips: [CreateClipInput!]
 	trackIds: [ID!]
+	properties: EventPropertiesInput
+}
+
+input EventPropertiesInput {
+	siteIds: [ID!]
+	dataSourceIds: [ID!]
+	tags: [String!]
 }

--- a/graphql/api/domains/events/filter.graphqls
+++ b/graphql/api/domains/events/filter.graphqls
@@ -12,6 +12,7 @@ input FilterEventInput {
 	type: FilterStringInput
 	subType: FilterStringInput
 	time: FilterDateTimeOffsetInput!
+	draft: FilterBooleanInput
 
 	and: [FilterEventInput!]
 	or: [FilterEventInput!]
@@ -22,6 +23,7 @@ input FilterEventActivityInput {
 	eventProducerId: FilterIDInput
 	type: FilterStringInput
 	subType: FilterStringInput
+	draft: FilterBooleanInput
 
 	and: [FilterEventActivityInput!]
 	or: [FilterEventActivityInput!]

--- a/java/src/main/java/io/worlds/api/model/CreateEventInput.java
+++ b/java/src/main/java/io/worlds/api/model/CreateEventInput.java
@@ -21,11 +21,13 @@ public class CreateEventInput implements java.io.Serializable {
     private java.util.List<UploadImageInput> uploads;
     private java.util.List<CreateClipInput> clips;
     private java.util.List<String> trackIds;
+    private org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> properties = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<Boolean> draft = org.springframework.graphql.data.ArgumentValue.omitted();
 
     public CreateEventInput() {
     }
 
-    public CreateEventInput(org.springframework.graphql.data.ArgumentValue<String> id, String eventProducerId, String type, org.springframework.graphql.data.ArgumentValue<String> subType, java.time.OffsetDateTime startTime, org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> endTime, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, org.springframework.graphql.data.ArgumentValue<String> timezone, org.springframework.graphql.data.ArgumentValue<java.lang.Object> metadata, java.util.List<CreateSnapshotInput> snapshots, java.util.List<UploadImageInput> uploads, java.util.List<CreateClipInput> clips, java.util.List<String> trackIds) {
+    public CreateEventInput(org.springframework.graphql.data.ArgumentValue<String> id, String eventProducerId, String type, org.springframework.graphql.data.ArgumentValue<String> subType, java.time.OffsetDateTime startTime, org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> endTime, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, org.springframework.graphql.data.ArgumentValue<String> timezone, org.springframework.graphql.data.ArgumentValue<java.lang.Object> metadata, java.util.List<CreateSnapshotInput> snapshots, java.util.List<UploadImageInput> uploads, java.util.List<CreateClipInput> clips, java.util.List<String> trackIds, org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> properties, org.springframework.graphql.data.ArgumentValue<Boolean> draft) {
         this.id = id;
         this.eventProducerId = eventProducerId;
         this.type = type;
@@ -39,6 +41,8 @@ public class CreateEventInput implements java.io.Serializable {
         this.uploads = uploads;
         this.clips = clips;
         this.trackIds = trackIds;
+        this.properties = properties;
+        this.draft = draft;
     }
 
     public org.springframework.graphql.data.ArgumentValue<String> getId() {
@@ -132,6 +136,20 @@ public class CreateEventInput implements java.io.Serializable {
         this.trackIds = trackIds;
     }
 
+    public org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> getProperties() {
+        return properties;
+    }
+    public void setProperties(org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> properties) {
+        this.properties = properties;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<Boolean> getDraft() {
+        return draft;
+    }
+    public void setDraft(org.springframework.graphql.data.ArgumentValue<Boolean> draft) {
+        this.draft = draft;
+    }
+
 
 
     public static CreateEventInput.Builder builder() {
@@ -153,6 +171,8 @@ public class CreateEventInput implements java.io.Serializable {
         private java.util.List<UploadImageInput> uploads;
         private java.util.List<CreateClipInput> clips;
         private java.util.List<String> trackIds;
+        private org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> properties = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<Boolean> draft = org.springframework.graphql.data.ArgumentValue.omitted();
 
         public Builder() {
         }
@@ -222,9 +242,19 @@ public class CreateEventInput implements java.io.Serializable {
             return this;
         }
 
+        public Builder setProperties(org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> properties) {
+            this.properties = properties;
+            return this;
+        }
+
+        public Builder setDraft(org.springframework.graphql.data.ArgumentValue<Boolean> draft) {
+            this.draft = draft;
+            return this;
+        }
+
 
         public CreateEventInput build() {
-            return new CreateEventInput(id, eventProducerId, type, subType, startTime, endTime, position, timezone, metadata, snapshots, uploads, clips, trackIds);
+            return new CreateEventInput(id, eventProducerId, type, subType, startTime, endTime, position, timezone, metadata, snapshots, uploads, clips, trackIds, properties, draft);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/CreateEventInput.java
+++ b/java/src/main/java/io/worlds/api/model/CreateEventInput.java
@@ -22,12 +22,12 @@ public class CreateEventInput implements java.io.Serializable {
     private java.util.List<CreateClipInput> clips;
     private java.util.List<String> trackIds;
     private org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> properties = org.springframework.graphql.data.ArgumentValue.omitted();
-    private org.springframework.graphql.data.ArgumentValue<Boolean> draft = org.springframework.graphql.data.ArgumentValue.omitted();
+    private boolean draft = false;
 
     public CreateEventInput() {
     }
 
-    public CreateEventInput(org.springframework.graphql.data.ArgumentValue<String> id, String eventProducerId, String type, org.springframework.graphql.data.ArgumentValue<String> subType, java.time.OffsetDateTime startTime, org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> endTime, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, org.springframework.graphql.data.ArgumentValue<String> timezone, org.springframework.graphql.data.ArgumentValue<java.lang.Object> metadata, java.util.List<CreateSnapshotInput> snapshots, java.util.List<UploadImageInput> uploads, java.util.List<CreateClipInput> clips, java.util.List<String> trackIds, org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> properties, org.springframework.graphql.data.ArgumentValue<Boolean> draft) {
+    public CreateEventInput(org.springframework.graphql.data.ArgumentValue<String> id, String eventProducerId, String type, org.springframework.graphql.data.ArgumentValue<String> subType, java.time.OffsetDateTime startTime, org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> endTime, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, org.springframework.graphql.data.ArgumentValue<String> timezone, org.springframework.graphql.data.ArgumentValue<java.lang.Object> metadata, java.util.List<CreateSnapshotInput> snapshots, java.util.List<UploadImageInput> uploads, java.util.List<CreateClipInput> clips, java.util.List<String> trackIds, org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> properties, boolean draft) {
         this.id = id;
         this.eventProducerId = eventProducerId;
         this.type = type;
@@ -143,10 +143,10 @@ public class CreateEventInput implements java.io.Serializable {
         this.properties = properties;
     }
 
-    public org.springframework.graphql.data.ArgumentValue<Boolean> getDraft() {
+    public boolean getDraft() {
         return draft;
     }
-    public void setDraft(org.springframework.graphql.data.ArgumentValue<Boolean> draft) {
+    public void setDraft(boolean draft) {
         this.draft = draft;
     }
 
@@ -172,7 +172,7 @@ public class CreateEventInput implements java.io.Serializable {
         private java.util.List<CreateClipInput> clips;
         private java.util.List<String> trackIds;
         private org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> properties = org.springframework.graphql.data.ArgumentValue.omitted();
-        private org.springframework.graphql.data.ArgumentValue<Boolean> draft = org.springframework.graphql.data.ArgumentValue.omitted();
+        private boolean draft = false;
 
         public Builder() {
         }
@@ -247,7 +247,7 @@ public class CreateEventInput implements java.io.Serializable {
             return this;
         }
 
-        public Builder setDraft(org.springframework.graphql.data.ArgumentValue<Boolean> draft) {
+        public Builder setDraft(boolean draft) {
             this.draft = draft;
             return this;
         }

--- a/java/src/main/java/io/worlds/api/model/Event.java
+++ b/java/src/main/java/io/worlds/api/model/Event.java
@@ -22,11 +22,13 @@ public class Event implements java.io.Serializable {
     private java.util.List<Image> images;
     @jakarta.validation.constraints.NotNull
     private java.util.List<Video> videos;
+    private EventProperties properties;
+    private Boolean draft;
 
     public Event() {
     }
 
-    public Event(String id, EventProducer eventProducer, String type, String subType, java.time.OffsetDateTime startTime, java.time.OffsetDateTime endTime, GeoJSONPoint position, String timezone, java.lang.Object metadata, java.util.List<Image> images, java.util.List<Video> videos) {
+    public Event(String id, EventProducer eventProducer, String type, String subType, java.time.OffsetDateTime startTime, java.time.OffsetDateTime endTime, GeoJSONPoint position, String timezone, java.lang.Object metadata, java.util.List<Image> images, java.util.List<Video> videos, EventProperties properties, Boolean draft) {
         this.id = id;
         this.eventProducer = eventProducer;
         this.type = type;
@@ -38,6 +40,8 @@ public class Event implements java.io.Serializable {
         this.metadata = metadata;
         this.images = images;
         this.videos = videos;
+        this.properties = properties;
+        this.draft = draft;
     }
 
     public String getId() {
@@ -117,6 +121,20 @@ public class Event implements java.io.Serializable {
         this.videos = videos;
     }
 
+    public EventProperties getProperties() {
+        return properties;
+    }
+    public void setProperties(EventProperties properties) {
+        this.properties = properties;
+    }
+
+    public Boolean getDraft() {
+        return draft;
+    }
+    public void setDraft(Boolean draft) {
+        this.draft = draft;
+    }
+
 
 
     public static Event.Builder builder() {
@@ -136,6 +154,8 @@ public class Event implements java.io.Serializable {
         private java.lang.Object metadata;
         private java.util.List<Image> images;
         private java.util.List<Video> videos;
+        private EventProperties properties;
+        private Boolean draft;
 
         public Builder() {
         }
@@ -195,9 +215,19 @@ public class Event implements java.io.Serializable {
             return this;
         }
 
+        public Builder setProperties(EventProperties properties) {
+            this.properties = properties;
+            return this;
+        }
+
+        public Builder setDraft(Boolean draft) {
+            this.draft = draft;
+            return this;
+        }
+
 
         public Event build() {
-            return new Event(id, eventProducer, type, subType, startTime, endTime, position, timezone, metadata, images, videos);
+            return new Event(id, eventProducer, type, subType, startTime, endTime, position, timezone, metadata, images, videos, properties, draft);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/EventProperties.java
+++ b/java/src/main/java/io/worlds/api/model/EventProperties.java
@@ -1,0 +1,78 @@
+package io.worlds.api.model;
+
+
+public class EventProperties implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private java.util.List<Site> sites;
+    private java.util.List<DataSource> dataSources;
+    private java.util.List<Tag> tags;
+
+    public EventProperties() {
+    }
+
+    public EventProperties(java.util.List<Site> sites, java.util.List<DataSource> dataSources, java.util.List<Tag> tags) {
+        this.sites = sites;
+        this.dataSources = dataSources;
+        this.tags = tags;
+    }
+
+    public java.util.List<Site> getSites() {
+        return sites;
+    }
+    public void setSites(java.util.List<Site> sites) {
+        this.sites = sites;
+    }
+
+    public java.util.List<DataSource> getDataSources() {
+        return dataSources;
+    }
+    public void setDataSources(java.util.List<DataSource> dataSources) {
+        this.dataSources = dataSources;
+    }
+
+    public java.util.List<Tag> getTags() {
+        return tags;
+    }
+    public void setTags(java.util.List<Tag> tags) {
+        this.tags = tags;
+    }
+
+
+
+    public static EventProperties.Builder builder() {
+        return new EventProperties.Builder();
+    }
+
+    public static class Builder {
+
+        private java.util.List<Site> sites;
+        private java.util.List<DataSource> dataSources;
+        private java.util.List<Tag> tags;
+
+        public Builder() {
+        }
+
+        public Builder setSites(java.util.List<Site> sites) {
+            this.sites = sites;
+            return this;
+        }
+
+        public Builder setDataSources(java.util.List<DataSource> dataSources) {
+            this.dataSources = dataSources;
+            return this;
+        }
+
+        public Builder setTags(java.util.List<Tag> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+
+        public EventProperties build() {
+            return new EventProperties(sites, dataSources, tags);
+        }
+
+    }
+}

--- a/java/src/main/java/io/worlds/api/model/EventPropertiesInput.java
+++ b/java/src/main/java/io/worlds/api/model/EventPropertiesInput.java
@@ -1,0 +1,78 @@
+package io.worlds.api.model;
+
+
+public class EventPropertiesInput implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private java.util.List<String> siteIds;
+    private java.util.List<String> dataSourceIds;
+    private java.util.List<String> tags;
+
+    public EventPropertiesInput() {
+    }
+
+    public EventPropertiesInput(java.util.List<String> siteIds, java.util.List<String> dataSourceIds, java.util.List<String> tags) {
+        this.siteIds = siteIds;
+        this.dataSourceIds = dataSourceIds;
+        this.tags = tags;
+    }
+
+    public java.util.List<String> getSiteIds() {
+        return siteIds;
+    }
+    public void setSiteIds(java.util.List<String> siteIds) {
+        this.siteIds = siteIds;
+    }
+
+    public java.util.List<String> getDataSourceIds() {
+        return dataSourceIds;
+    }
+    public void setDataSourceIds(java.util.List<String> dataSourceIds) {
+        this.dataSourceIds = dataSourceIds;
+    }
+
+    public java.util.List<String> getTags() {
+        return tags;
+    }
+    public void setTags(java.util.List<String> tags) {
+        this.tags = tags;
+    }
+
+
+
+    public static EventPropertiesInput.Builder builder() {
+        return new EventPropertiesInput.Builder();
+    }
+
+    public static class Builder {
+
+        private java.util.List<String> siteIds;
+        private java.util.List<String> dataSourceIds;
+        private java.util.List<String> tags;
+
+        public Builder() {
+        }
+
+        public Builder setSiteIds(java.util.List<String> siteIds) {
+            this.siteIds = siteIds;
+            return this;
+        }
+
+        public Builder setDataSourceIds(java.util.List<String> dataSourceIds) {
+            this.dataSourceIds = dataSourceIds;
+            return this;
+        }
+
+        public Builder setTags(java.util.List<String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+
+        public EventPropertiesInput build() {
+            return new EventPropertiesInput(siteIds, dataSourceIds, tags);
+        }
+
+    }
+}

--- a/java/src/main/java/io/worlds/api/model/FilterEventActivityInput.java
+++ b/java/src/main/java/io/worlds/api/model/FilterEventActivityInput.java
@@ -8,6 +8,7 @@ public class FilterEventActivityInput implements java.io.Serializable {
     private org.springframework.graphql.data.ArgumentValue<FilterIDInput> eventProducerId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> type = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> subType = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> draft = org.springframework.graphql.data.ArgumentValue.omitted();
     private java.util.List<FilterEventActivityInput> and;
     private java.util.List<FilterEventActivityInput> or;
     private org.springframework.graphql.data.ArgumentValue<FilterEventActivityInput> not = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -15,10 +16,11 @@ public class FilterEventActivityInput implements java.io.Serializable {
     public FilterEventActivityInput() {
     }
 
-    public FilterEventActivityInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> eventProducerId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> type, org.springframework.graphql.data.ArgumentValue<FilterStringInput> subType, java.util.List<FilterEventActivityInput> and, java.util.List<FilterEventActivityInput> or, org.springframework.graphql.data.ArgumentValue<FilterEventActivityInput> not) {
+    public FilterEventActivityInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> eventProducerId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> type, org.springframework.graphql.data.ArgumentValue<FilterStringInput> subType, org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> draft, java.util.List<FilterEventActivityInput> and, java.util.List<FilterEventActivityInput> or, org.springframework.graphql.data.ArgumentValue<FilterEventActivityInput> not) {
         this.eventProducerId = eventProducerId;
         this.type = type;
         this.subType = subType;
+        this.draft = draft;
         this.and = and;
         this.or = or;
         this.not = not;
@@ -43,6 +45,13 @@ public class FilterEventActivityInput implements java.io.Serializable {
     }
     public void setSubType(org.springframework.graphql.data.ArgumentValue<FilterStringInput> subType) {
         this.subType = subType;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> getDraft() {
+        return draft;
+    }
+    public void setDraft(org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> draft) {
+        this.draft = draft;
     }
 
     public java.util.List<FilterEventActivityInput> getAnd() {
@@ -77,6 +86,7 @@ public class FilterEventActivityInput implements java.io.Serializable {
         private org.springframework.graphql.data.ArgumentValue<FilterIDInput> eventProducerId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> type = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> subType = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> draft = org.springframework.graphql.data.ArgumentValue.omitted();
         private java.util.List<FilterEventActivityInput> and;
         private java.util.List<FilterEventActivityInput> or;
         private org.springframework.graphql.data.ArgumentValue<FilterEventActivityInput> not = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -99,6 +109,11 @@ public class FilterEventActivityInput implements java.io.Serializable {
             return this;
         }
 
+        public Builder setDraft(org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> draft) {
+            this.draft = draft;
+            return this;
+        }
+
         public Builder setAnd(java.util.List<FilterEventActivityInput> and) {
             this.and = and;
             return this;
@@ -116,7 +131,7 @@ public class FilterEventActivityInput implements java.io.Serializable {
 
 
         public FilterEventActivityInput build() {
-            return new FilterEventActivityInput(eventProducerId, type, subType, and, or, not);
+            return new FilterEventActivityInput(eventProducerId, type, subType, draft, and, or, not);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/FilterEventInput.java
+++ b/java/src/main/java/io/worlds/api/model/FilterEventInput.java
@@ -10,6 +10,7 @@ public class FilterEventInput implements java.io.Serializable {
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> subType = org.springframework.graphql.data.ArgumentValue.omitted();
     @jakarta.validation.constraints.NotNull
     private FilterDateTimeOffsetInput time;
+    private org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> draft = org.springframework.graphql.data.ArgumentValue.omitted();
     private java.util.List<FilterEventInput> and;
     private java.util.List<FilterEventInput> or;
     private org.springframework.graphql.data.ArgumentValue<FilterEventInput> not = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -17,11 +18,12 @@ public class FilterEventInput implements java.io.Serializable {
     public FilterEventInput() {
     }
 
-    public FilterEventInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> eventProducerId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> type, org.springframework.graphql.data.ArgumentValue<FilterStringInput> subType, FilterDateTimeOffsetInput time, java.util.List<FilterEventInput> and, java.util.List<FilterEventInput> or, org.springframework.graphql.data.ArgumentValue<FilterEventInput> not) {
+    public FilterEventInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> eventProducerId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> type, org.springframework.graphql.data.ArgumentValue<FilterStringInput> subType, FilterDateTimeOffsetInput time, org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> draft, java.util.List<FilterEventInput> and, java.util.List<FilterEventInput> or, org.springframework.graphql.data.ArgumentValue<FilterEventInput> not) {
         this.eventProducerId = eventProducerId;
         this.type = type;
         this.subType = subType;
         this.time = time;
+        this.draft = draft;
         this.and = and;
         this.or = or;
         this.not = not;
@@ -53,6 +55,13 @@ public class FilterEventInput implements java.io.Serializable {
     }
     public void setTime(FilterDateTimeOffsetInput time) {
         this.time = time;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> getDraft() {
+        return draft;
+    }
+    public void setDraft(org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> draft) {
+        this.draft = draft;
     }
 
     public java.util.List<FilterEventInput> getAnd() {
@@ -88,6 +97,7 @@ public class FilterEventInput implements java.io.Serializable {
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> type = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> subType = org.springframework.graphql.data.ArgumentValue.omitted();
         private FilterDateTimeOffsetInput time;
+        private org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> draft = org.springframework.graphql.data.ArgumentValue.omitted();
         private java.util.List<FilterEventInput> and;
         private java.util.List<FilterEventInput> or;
         private org.springframework.graphql.data.ArgumentValue<FilterEventInput> not = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -115,6 +125,11 @@ public class FilterEventInput implements java.io.Serializable {
             return this;
         }
 
+        public Builder setDraft(org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> draft) {
+            this.draft = draft;
+            return this;
+        }
+
         public Builder setAnd(java.util.List<FilterEventInput> and) {
             this.and = and;
             return this;
@@ -132,7 +147,7 @@ public class FilterEventInput implements java.io.Serializable {
 
 
         public FilterEventInput build() {
-            return new FilterEventInput(eventProducerId, type, subType, time, and, or, not);
+            return new FilterEventInput(eventProducerId, type, subType, time, draft, and, or, not);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/UpdateEventInput.java
+++ b/java/src/main/java/io/worlds/api/model/UpdateEventInput.java
@@ -20,11 +20,13 @@ public class UpdateEventInput implements java.io.Serializable {
     private java.util.List<UploadImageInput> uploads;
     private java.util.List<CreateClipInput> clips;
     private java.util.List<String> trackIds;
+    private org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> properties = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<Boolean> draft = org.springframework.graphql.data.ArgumentValue.omitted();
 
     public UpdateEventInput() {
     }
 
-    public UpdateEventInput(String id, String type, org.springframework.graphql.data.ArgumentValue<String> subType, java.time.OffsetDateTime startTime, org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> endTime, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, org.springframework.graphql.data.ArgumentValue<String> timezone, org.springframework.graphql.data.ArgumentValue<java.lang.Object> metadata, java.util.List<CreateSnapshotInput> snapshots, java.util.List<UploadImageInput> uploads, java.util.List<CreateClipInput> clips, java.util.List<String> trackIds) {
+    public UpdateEventInput(String id, String type, org.springframework.graphql.data.ArgumentValue<String> subType, java.time.OffsetDateTime startTime, org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> endTime, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, org.springframework.graphql.data.ArgumentValue<String> timezone, org.springframework.graphql.data.ArgumentValue<java.lang.Object> metadata, java.util.List<CreateSnapshotInput> snapshots, java.util.List<UploadImageInput> uploads, java.util.List<CreateClipInput> clips, java.util.List<String> trackIds, org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> properties, org.springframework.graphql.data.ArgumentValue<Boolean> draft) {
         this.id = id;
         this.type = type;
         this.subType = subType;
@@ -37,6 +39,8 @@ public class UpdateEventInput implements java.io.Serializable {
         this.uploads = uploads;
         this.clips = clips;
         this.trackIds = trackIds;
+        this.properties = properties;
+        this.draft = draft;
     }
 
     public String getId() {
@@ -123,6 +127,20 @@ public class UpdateEventInput implements java.io.Serializable {
         this.trackIds = trackIds;
     }
 
+    public org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> getProperties() {
+        return properties;
+    }
+    public void setProperties(org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> properties) {
+        this.properties = properties;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<Boolean> getDraft() {
+        return draft;
+    }
+    public void setDraft(org.springframework.graphql.data.ArgumentValue<Boolean> draft) {
+        this.draft = draft;
+    }
+
 
 
     public static UpdateEventInput.Builder builder() {
@@ -143,6 +161,8 @@ public class UpdateEventInput implements java.io.Serializable {
         private java.util.List<UploadImageInput> uploads;
         private java.util.List<CreateClipInput> clips;
         private java.util.List<String> trackIds;
+        private org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> properties = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<Boolean> draft = org.springframework.graphql.data.ArgumentValue.omitted();
 
         public Builder() {
         }
@@ -207,9 +227,19 @@ public class UpdateEventInput implements java.io.Serializable {
             return this;
         }
 
+        public Builder setProperties(org.springframework.graphql.data.ArgumentValue<EventPropertiesInput> properties) {
+            this.properties = properties;
+            return this;
+        }
+
+        public Builder setDraft(org.springframework.graphql.data.ArgumentValue<Boolean> draft) {
+            this.draft = draft;
+            return this;
+        }
+
 
         public UpdateEventInput build() {
-            return new UpdateEventInput(id, type, subType, startTime, endTime, position, timezone, metadata, snapshots, uploads, clips, trackIds);
+            return new UpdateEventInput(id, type, subType, startTime, endTime, position, timezone, metadata, snapshots, uploads, clips, trackIds, properties, draft);
         }
 
     }


### PR DESCRIPTION
## Description of Changes

Add `draft` field to events.  Allow filtering searches and subscriptions by `draft`.

Add `eventProperties` to events.

## Link to Related Jira Ticket

[CE-3158]
[CE-3155]
[CE-3154]

[CE-3158]: https://worlds-io.atlassian.net/browse/CE-3158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CE-3155]: https://worlds-io.atlassian.net/browse/CE-3155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CE-3154]: https://worlds-io.atlassian.net/browse/CE-3154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ