### PR TITLE
CE-3543: API mutation to create and edit zones

### DIFF
--- a/graphql/api/domains/zone/filter.graphqls
+++ b/graphql/api/domains/zone/filter.graphqls
@@ -3,6 +3,8 @@ input FilterZoneInput {
 	name: FilterStringInput
 	dataSourceId: FilterIDInput
 	active: FilterBooleanInput
+	createdAt: FilterDateTimeOffsetInput
+	updatedAt: FilterDateTimeOffsetInput
 
 	and: [FilterZoneInput!]
 	or: [FilterZoneInput!]

--- a/graphql/api/domains/zone/mutation.graphqls
+++ b/graphql/api/domains/zone/mutation.graphqls
@@ -1,0 +1,4 @@
+extend type Mutation {
+	createZone(zone: CreateZoneInput!): Zone
+	updateZone(zone: UpdateZoneInput!): Zone
+}

--- a/graphql/api/domains/zone/zone.graphqls
+++ b/graphql/api/domains/zone/zone.graphqls
@@ -31,3 +31,19 @@ type ZoneIntersectionMessage {
 	message: ZoneIntersection!
 	state: MessageState!
 }
+
+input CreateZoneInput {
+	id: ID!
+	dataSourceId: ID!
+	name: String!
+	polygon: GeoJSONPolygonInput!
+	active: Boolean
+}
+
+input UpdateZoneInput {
+	id: ID!
+	dataSourceId: ID
+	name: String
+	polygon: GeoJSONPolygonInput
+	active: Boolean
+}

--- a/graphql/api/domains/zone/zone.graphqls
+++ b/graphql/api/domains/zone/zone.graphqls
@@ -4,6 +4,8 @@ type Zone {
 	name: String!
 	polygon: GeoJSONPolygon! 
 	active: Boolean!
+	createdAt: DateTimeOffset
+	updatedAt: DateTimeOffset
 	
 	deviceId: ID! @deprecated (reason: "deviceId is deprecated, use dataSource.id instead")
 }

--- a/graphql/api/domains/zone/zone.graphqls
+++ b/graphql/api/domains/zone/zone.graphqls
@@ -33,7 +33,6 @@ type ZoneIntersectionMessage {
 }
 
 input CreateZoneInput {
-	id: ID!
 	dataSourceId: ID!
 	name: String!
 	polygon: GeoJSONPolygonInput!

--- a/java/src/main/java/io/worlds/api/model/CreateZoneInput.java
+++ b/java/src/main/java/io/worlds/api/model/CreateZoneInput.java
@@ -1,0 +1,96 @@
+package io.worlds.api.model;
+
+
+public class CreateZoneInput implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @jakarta.validation.constraints.NotNull
+    private String dataSourceId;
+    @jakarta.validation.constraints.NotNull
+    private String name;
+    @jakarta.validation.constraints.NotNull
+    private GeoJSONPolygonInput polygon;
+    private org.springframework.graphql.data.ArgumentValue<Boolean> active = org.springframework.graphql.data.ArgumentValue.omitted();
+
+    public CreateZoneInput() {
+    }
+
+    public CreateZoneInput(String dataSourceId, String name, GeoJSONPolygonInput polygon, org.springframework.graphql.data.ArgumentValue<Boolean> active) {
+        this.dataSourceId = dataSourceId;
+        this.name = name;
+        this.polygon = polygon;
+        this.active = active;
+    }
+
+    public String getDataSourceId() {
+        return dataSourceId;
+    }
+    public void setDataSourceId(String dataSourceId) {
+        this.dataSourceId = dataSourceId;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public GeoJSONPolygonInput getPolygon() {
+        return polygon;
+    }
+    public void setPolygon(GeoJSONPolygonInput polygon) {
+        this.polygon = polygon;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<Boolean> getActive() {
+        return active;
+    }
+    public void setActive(org.springframework.graphql.data.ArgumentValue<Boolean> active) {
+        this.active = active;
+    }
+
+
+
+    public static CreateZoneInput.Builder builder() {
+        return new CreateZoneInput.Builder();
+    }
+
+    public static class Builder {
+
+        private String dataSourceId;
+        private String name;
+        private GeoJSONPolygonInput polygon;
+        private org.springframework.graphql.data.ArgumentValue<Boolean> active = org.springframework.graphql.data.ArgumentValue.omitted();
+
+        public Builder() {
+        }
+
+        public Builder setDataSourceId(String dataSourceId) {
+            this.dataSourceId = dataSourceId;
+            return this;
+        }
+
+        public Builder setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder setPolygon(GeoJSONPolygonInput polygon) {
+            this.polygon = polygon;
+            return this;
+        }
+
+        public Builder setActive(org.springframework.graphql.data.ArgumentValue<Boolean> active) {
+            this.active = active;
+            return this;
+        }
+
+
+        public CreateZoneInput build() {
+            return new CreateZoneInput(dataSourceId, name, polygon, active);
+        }
+
+    }
+}

--- a/java/src/main/java/io/worlds/api/model/FilterZoneInput.java
+++ b/java/src/main/java/io/worlds/api/model/FilterZoneInput.java
@@ -9,6 +9,8 @@ public class FilterZoneInput implements java.io.Serializable {
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> name = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> active = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> createdAt = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> updatedAt = org.springframework.graphql.data.ArgumentValue.omitted();
     private java.util.List<FilterZoneInput> and;
     private java.util.List<FilterZoneInput> or;
     private org.springframework.graphql.data.ArgumentValue<FilterZoneInput> not = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -16,11 +18,13 @@ public class FilterZoneInput implements java.io.Serializable {
     public FilterZoneInput() {
     }
 
-    public FilterZoneInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterStringInput> name, org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId, org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> active, java.util.List<FilterZoneInput> and, java.util.List<FilterZoneInput> or, org.springframework.graphql.data.ArgumentValue<FilterZoneInput> not) {
+    public FilterZoneInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterStringInput> name, org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId, org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> active, org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> createdAt, org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> updatedAt, java.util.List<FilterZoneInput> and, java.util.List<FilterZoneInput> or, org.springframework.graphql.data.ArgumentValue<FilterZoneInput> not) {
         this.id = id;
         this.name = name;
         this.dataSourceId = dataSourceId;
         this.active = active;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
         this.and = and;
         this.or = or;
         this.not = not;
@@ -52,6 +56,20 @@ public class FilterZoneInput implements java.io.Serializable {
     }
     public void setActive(org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> active) {
         this.active = active;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> getCreatedAt() {
+        return createdAt;
+    }
+    public void setCreatedAt(org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> getUpdatedAt() {
+        return updatedAt;
+    }
+    public void setUpdatedAt(org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> updatedAt) {
+        this.updatedAt = updatedAt;
     }
 
     public java.util.List<FilterZoneInput> getAnd() {
@@ -87,6 +105,8 @@ public class FilterZoneInput implements java.io.Serializable {
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> name = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> active = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> createdAt = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> updatedAt = org.springframework.graphql.data.ArgumentValue.omitted();
         private java.util.List<FilterZoneInput> and;
         private java.util.List<FilterZoneInput> or;
         private org.springframework.graphql.data.ArgumentValue<FilterZoneInput> not = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -114,6 +134,16 @@ public class FilterZoneInput implements java.io.Serializable {
             return this;
         }
 
+        public Builder setCreatedAt(org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public Builder setUpdatedAt(org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> updatedAt) {
+            this.updatedAt = updatedAt;
+            return this;
+        }
+
         public Builder setAnd(java.util.List<FilterZoneInput> and) {
             this.and = and;
             return this;
@@ -131,7 +161,7 @@ public class FilterZoneInput implements java.io.Serializable {
 
 
         public FilterZoneInput build() {
-            return new FilterZoneInput(id, name, dataSourceId, active, and, or, not);
+            return new FilterZoneInput(id, name, dataSourceId, active, createdAt, updatedAt, and, or, not);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/UpdateZoneInput.java
+++ b/java/src/main/java/io/worlds/api/model/UpdateZoneInput.java
@@ -1,0 +1,109 @@
+package io.worlds.api.model;
+
+
+public class UpdateZoneInput implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @jakarta.validation.constraints.NotNull
+    private String id;
+    private org.springframework.graphql.data.ArgumentValue<String> dataSourceId = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<String> name = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<GeoJSONPolygonInput> polygon = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<Boolean> active = org.springframework.graphql.data.ArgumentValue.omitted();
+
+    public UpdateZoneInput() {
+    }
+
+    public UpdateZoneInput(String id, org.springframework.graphql.data.ArgumentValue<String> dataSourceId, org.springframework.graphql.data.ArgumentValue<String> name, org.springframework.graphql.data.ArgumentValue<GeoJSONPolygonInput> polygon, org.springframework.graphql.data.ArgumentValue<Boolean> active) {
+        this.id = id;
+        this.dataSourceId = dataSourceId;
+        this.name = name;
+        this.polygon = polygon;
+        this.active = active;
+    }
+
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<String> getDataSourceId() {
+        return dataSourceId;
+    }
+    public void setDataSourceId(org.springframework.graphql.data.ArgumentValue<String> dataSourceId) {
+        this.dataSourceId = dataSourceId;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<String> getName() {
+        return name;
+    }
+    public void setName(org.springframework.graphql.data.ArgumentValue<String> name) {
+        this.name = name;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<GeoJSONPolygonInput> getPolygon() {
+        return polygon;
+    }
+    public void setPolygon(org.springframework.graphql.data.ArgumentValue<GeoJSONPolygonInput> polygon) {
+        this.polygon = polygon;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<Boolean> getActive() {
+        return active;
+    }
+    public void setActive(org.springframework.graphql.data.ArgumentValue<Boolean> active) {
+        this.active = active;
+    }
+
+
+
+    public static UpdateZoneInput.Builder builder() {
+        return new UpdateZoneInput.Builder();
+    }
+
+    public static class Builder {
+
+        private String id;
+        private org.springframework.graphql.data.ArgumentValue<String> dataSourceId = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<String> name = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<GeoJSONPolygonInput> polygon = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<Boolean> active = org.springframework.graphql.data.ArgumentValue.omitted();
+
+        public Builder() {
+        }
+
+        public Builder setId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setDataSourceId(org.springframework.graphql.data.ArgumentValue<String> dataSourceId) {
+            this.dataSourceId = dataSourceId;
+            return this;
+        }
+
+        public Builder setName(org.springframework.graphql.data.ArgumentValue<String> name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder setPolygon(org.springframework.graphql.data.ArgumentValue<GeoJSONPolygonInput> polygon) {
+            this.polygon = polygon;
+            return this;
+        }
+
+        public Builder setActive(org.springframework.graphql.data.ArgumentValue<Boolean> active) {
+            this.active = active;
+            return this;
+        }
+
+
+        public UpdateZoneInput build() {
+            return new UpdateZoneInput(id, dataSourceId, name, polygon, active);
+        }
+
+    }
+}

--- a/java/src/main/java/io/worlds/api/model/Zone.java
+++ b/java/src/main/java/io/worlds/api/model/Zone.java
@@ -13,6 +13,8 @@ public class Zone implements java.io.Serializable {
     @jakarta.validation.constraints.NotNull
     private GeoJSONPolygon polygon;
     private boolean active;
+    private java.time.OffsetDateTime createdAt;
+    private java.time.OffsetDateTime updatedAt;
     @Deprecated
     @jakarta.validation.constraints.NotNull
     private String deviceId;
@@ -20,12 +22,14 @@ public class Zone implements java.io.Serializable {
     public Zone() {
     }
 
-    public Zone(String id, DataSource dataSource, String name, GeoJSONPolygon polygon, boolean active, String deviceId) {
+    public Zone(String id, DataSource dataSource, String name, GeoJSONPolygon polygon, boolean active, java.time.OffsetDateTime createdAt, java.time.OffsetDateTime updatedAt, String deviceId) {
         this.id = id;
         this.dataSource = dataSource;
         this.name = name;
         this.polygon = polygon;
         this.active = active;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
         this.deviceId = deviceId;
     }
 
@@ -64,6 +68,20 @@ public class Zone implements java.io.Serializable {
         this.active = active;
     }
 
+    public java.time.OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+    public void setCreatedAt(java.time.OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public java.time.OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+    public void setUpdatedAt(java.time.OffsetDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
     @Deprecated
     public String getDeviceId() {
         return deviceId;
@@ -86,6 +104,8 @@ public class Zone implements java.io.Serializable {
         private String name;
         private GeoJSONPolygon polygon;
         private boolean active;
+        private java.time.OffsetDateTime createdAt;
+        private java.time.OffsetDateTime updatedAt;
         private String deviceId;
 
         public Builder() {
@@ -116,6 +136,16 @@ public class Zone implements java.io.Serializable {
             return this;
         }
 
+        public Builder setCreatedAt(java.time.OffsetDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public Builder setUpdatedAt(java.time.OffsetDateTime updatedAt) {
+            this.updatedAt = updatedAt;
+            return this;
+        }
+
         @Deprecated
         public Builder setDeviceId(String deviceId) {
             this.deviceId = deviceId;
@@ -124,7 +154,7 @@ public class Zone implements java.io.Serializable {
 
 
         public Zone build() {
-            return new Zone(id, dataSource, name, polygon, active, deviceId);
+            return new Zone(id, dataSource, name, polygon, active, createdAt, updatedAt, deviceId);
         }
 
     }


### PR DESCRIPTION
## Description of Changes
- Add `createZone` and `updateZone` mutation.
- Add `createdAt` and `updatedAt` fields and filters for Zones.


## Link to Related Jira Ticket
[CE-3543]

[CE-3543]: https://worlds-io.atlassian.net/browse/CE-3543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ