### PR TITLE
CE-3636: Add schema for text reading endpoints

### DIFF
--- a/graphql/api/domains/inference/inference.graphqls
+++ b/graphql/api/domains/inference/inference.graphqls
@@ -1,5 +1,17 @@
 ### Text Recognition ###
 
+type TextReadingResponse {
+    text: String!
+    textConfidence: Float!
+}
+
+type TextReading {
+    text: String!
+    textConfidence: Float!
+}
+
+### Text Recognition ###
+
 input TextRecognitionOptionsInput {
     regions: [GeoJSONMultiPolygonInput!]
 }

--- a/graphql/api/domains/inference/inference.graphqls
+++ b/graphql/api/domains/inference/inference.graphqls
@@ -5,11 +5,6 @@ type TextReadingResponse {
     textConfidence: Float!
 }
 
-type TextReading {
-    text: String!
-    textConfidence: Float!
-}
-
 ### Text Recognition ###
 
 input TextRecognitionOptionsInput {

--- a/graphql/api/domains/inference/inference.graphqls
+++ b/graphql/api/domains/inference/inference.graphqls
@@ -1,4 +1,4 @@
-### Text Recognition ###
+### Text Reading ###
 
 type TextReadingResponse {
     text: String!

--- a/graphql/api/domains/inference/query.graphqls
+++ b/graphql/api/domains/inference/query.graphqls
@@ -1,4 +1,7 @@
 extend type Query {
+    textReadingForImage(imageId: ID!): TextReadingResponse
+    textReadingForUrl(url: String!): TextReadingResponse
+
     textRecognitionForDataSource(dataSourceId: ID!, timestamp: DateTimeOffset!, options: TextRecognitionOptionsInput): TextRecognitionResponse
     textRecognitionForVideo(videoId: ID!, timestamp: DateTimeOffset!, options: TextRecognitionOptionsInput): TextRecognitionResponse
     textRecognitionForFrame(frameId: ID!, options: TextRecognitionOptionsInput): TextRecognitionResponse

--- a/java/src/main/java/io/worlds/api/model/ChronicleValidationInput.java
+++ b/java/src/main/java/io/worlds/api/model/ChronicleValidationInput.java
@@ -10,15 +10,15 @@ public class ChronicleValidationInput implements java.io.Serializable {
 
     @jakarta.validation.constraints.NotNull
     private ChronicleValidationStatus status;
-    private org.springframework.graphql.data.ArgumentValue<String> reason = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<String> summary = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<String> details = org.springframework.graphql.data.ArgumentValue.omitted();
 
     public ChronicleValidationInput() {
     }
 
-    public ChronicleValidationInput(ChronicleValidationStatus status, org.springframework.graphql.data.ArgumentValue<String> reason, org.springframework.graphql.data.ArgumentValue<String> details) {
+    public ChronicleValidationInput(ChronicleValidationStatus status, org.springframework.graphql.data.ArgumentValue<String> summary, org.springframework.graphql.data.ArgumentValue<String> details) {
         this.status = status;
-        this.reason = reason;
+        this.summary = summary;
         this.details = details;
     }
 
@@ -29,11 +29,11 @@ public class ChronicleValidationInput implements java.io.Serializable {
         this.status = status;
     }
 
-    public org.springframework.graphql.data.ArgumentValue<String> getReason() {
-        return reason;
+    public org.springframework.graphql.data.ArgumentValue<String> getSummary() {
+        return summary;
     }
-    public void setReason(org.springframework.graphql.data.ArgumentValue<String> reason) {
-        this.reason = reason;
+    public void setSummary(org.springframework.graphql.data.ArgumentValue<String> summary) {
+        this.summary = summary;
     }
 
     public org.springframework.graphql.data.ArgumentValue<String> getDetails() {
@@ -52,7 +52,7 @@ public class ChronicleValidationInput implements java.io.Serializable {
     public static class Builder {
 
         private ChronicleValidationStatus status;
-        private org.springframework.graphql.data.ArgumentValue<String> reason = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<String> summary = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<String> details = org.springframework.graphql.data.ArgumentValue.omitted();
 
         public Builder() {
@@ -63,8 +63,8 @@ public class ChronicleValidationInput implements java.io.Serializable {
             return this;
         }
 
-        public Builder setReason(org.springframework.graphql.data.ArgumentValue<String> reason) {
-            this.reason = reason;
+        public Builder setSummary(org.springframework.graphql.data.ArgumentValue<String> summary) {
+            this.summary = summary;
             return this;
         }
 
@@ -75,7 +75,7 @@ public class ChronicleValidationInput implements java.io.Serializable {
 
 
         public ChronicleValidationInput build() {
-            return new ChronicleValidationInput(status, reason, details);
+            return new ChronicleValidationInput(status, summary, details);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/UpdateChronicleProducerInput.java
+++ b/java/src/main/java/io/worlds/api/model/UpdateChronicleProducerInput.java
@@ -5,6 +5,8 @@ public class UpdateChronicleProducerInput implements java.io.Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    @jakarta.validation.constraints.NotNull
+    private String id;
     private org.springframework.graphql.data.ArgumentValue<String> name = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<String> description = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<String> timezone = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -15,13 +17,21 @@ public class UpdateChronicleProducerInput implements java.io.Serializable {
     public UpdateChronicleProducerInput() {
     }
 
-    public UpdateChronicleProducerInput(org.springframework.graphql.data.ArgumentValue<String> name, org.springframework.graphql.data.ArgumentValue<String> description, org.springframework.graphql.data.ArgumentValue<String> timezone, org.springframework.graphql.data.ArgumentValue<Boolean> active, org.springframework.graphql.data.ArgumentValue<java.lang.Object> metadata, java.util.List<String> invalidReasons) {
+    public UpdateChronicleProducerInput(String id, org.springframework.graphql.data.ArgumentValue<String> name, org.springframework.graphql.data.ArgumentValue<String> description, org.springframework.graphql.data.ArgumentValue<String> timezone, org.springframework.graphql.data.ArgumentValue<Boolean> active, org.springframework.graphql.data.ArgumentValue<java.lang.Object> metadata, java.util.List<String> invalidReasons) {
+        this.id = id;
         this.name = name;
         this.description = description;
         this.timezone = timezone;
         this.active = active;
         this.metadata = metadata;
         this.invalidReasons = invalidReasons;
+    }
+
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
     }
 
     public org.springframework.graphql.data.ArgumentValue<String> getName() {
@@ -74,6 +84,7 @@ public class UpdateChronicleProducerInput implements java.io.Serializable {
 
     public static class Builder {
 
+        private String id;
         private org.springframework.graphql.data.ArgumentValue<String> name = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<String> description = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<String> timezone = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -82,6 +93,11 @@ public class UpdateChronicleProducerInput implements java.io.Serializable {
         private java.util.List<String> invalidReasons;
 
         public Builder() {
+        }
+
+        public Builder setId(String id) {
+            this.id = id;
+            return this;
         }
 
         public Builder setName(org.springframework.graphql.data.ArgumentValue<String> name) {
@@ -116,7 +132,7 @@ public class UpdateChronicleProducerInput implements java.io.Serializable {
 
 
         public UpdateChronicleProducerInput build() {
-            return new UpdateChronicleProducerInput(name, description, timezone, active, metadata, invalidReasons);
+            return new UpdateChronicleProducerInput(id, name, description, timezone, active, metadata, invalidReasons);
         }
 
     }


### PR DESCRIPTION
## Description of Changes
Add schema for text reading endpoints.  Unlike other inference endpoints, these endpoints require input images pre-cropped to text, so only endpoints for image and image URL inputs are created.

Also, generate sources for prior chronicle documents schema changes.

## Link to Related Jira Ticket
[CE-3636]

[CE-3636]: https://worlds-io.atlassian.net/browse/CE-3636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ