### PR TITLE
CE-4018: Add schema for create and update sites

### DIFF
--- a/graphql/api/domains/site/mutation.graphqls
+++ b/graphql/api/domains/site/mutation.graphqls
@@ -1,0 +1,14 @@
+extend type Mutation {
+    """Creates a new Site."""
+    createSite(
+        """Arguments to create a new site."""
+        site: CreateSiteInput!
+    ): Site
+    """
+    Updates an existing Site.
+    """
+    updateSite(
+        """Arguments to update an existing site."""
+        site: UpdateSiteInput!
+    ): Site
+}

--- a/graphql/api/domains/site/site.graphqls
+++ b/graphql/api/domains/site/site.graphqls
@@ -17,3 +17,29 @@ type Site {
     """The geofences that are associated with this site"""
     geofences: [Geofence!]!
 }
+
+"""
+Input type used to create a new [Site]({{Types.site}.
+"""
+input CreateSiteInput {
+    """The name of the site."""
+    name: String!
+    """The geographic location of the site"""
+    position: GeoJSONPointInput
+    """The geographic shape of the site"""
+    polygon: GeoJSONMultiPolygonInput
+}
+
+"""
+Input type used to update an existing [Site]({{Types.site}.
+"""
+input UpdateSiteInput {
+    """The unique identifier of the site."""
+    id: ID!
+    """The name of the site."""
+    name: String
+    """The geographic location of the site"""
+    position: GeoJSONPointInput
+    """The geographic shape of the site"""
+    polygon: GeoJSONMultiPolygonInput
+}


### PR DESCRIPTION
## Description of Changes
Add `createSite` and `updateSite` mutations.

## Link to Related Jira Ticket
[CE-4018]

[CE-4018]: https://worlds-io.atlassian.net/browse/CE-4018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ