### PR TITLE
CE-5193: Add bucket/filter by name and label to activity summary

### DIFF
--- a/graphql/api/domains/summary/filter.graphqls
+++ b/graphql/api/domains/summary/filter.graphqls
@@ -96,6 +96,10 @@ input FilterActivityChronicleSummaryInput {
     """
     siteIds: FilterIDListInput
     """
+    If provided, specifies filters that work against the labels of the activity.
+    """
+    labels: FilterStringListInput
+    """
     If provided, specifies filters that work against the priority of the activity.
     """
     priority: FilterStringInput

--- a/graphql/api/domains/summary/summary.graphqls
+++ b/graphql/api/domains/summary/summary.graphqls
@@ -211,7 +211,7 @@ type ActivityChronicleSummaryStatistics {
 type ActivityChronicleSummaryBucketKey {
     """The start time of the summary bucket."""
     time: DateTimeOffset
-    """The label of the activity chronicles in the summary bucket."""
+    """The name of the activity chronicles in the summary bucket."""
     name: String
     """The `priority` of the activity chronicles in the summary bucket."""
     priority: String

--- a/graphql/api/domains/summary/summary.graphqls
+++ b/graphql/api/domains/summary/summary.graphqls
@@ -211,6 +211,8 @@ type ActivityChronicleSummaryStatistics {
 type ActivityChronicleSummaryBucketKey {
     """The start time of the summary bucket."""
     time: DateTimeOffset
+    """The label of the activity chronicles in the summary bucket."""
+    name: String
     """The `priority` of the activity chronicles in the summary bucket."""
     priority: String
     """The `status` of the activity chronicles in the summary bucket."""
@@ -221,6 +223,8 @@ type ActivityChronicleSummaryBucketKey {
     site: Site
     """The DataSource of the activity chronicles in the summary bucket."""
     dataSource: DataSource
+    """The label of the activity chronicles in the summary bucket."""
+    label: String
     """The `validationStatus` of the activity chronicles in the summary bucket."""
     validationStatus: String
     """The `approvalStatus` of the activity chronicles in the summary bucket."""

--- a/graphql/api/domains/summary/util.graphqls
+++ b/graphql/api/domains/summary/util.graphqls
@@ -117,16 +117,20 @@ input VideosSummaryBucketType {
 
 """Indicates the bucket to group activity chronicles by in an activityChronicleSummary query."""
 enum ActivityChronicleSummaryBucketField {
+    """Bucket by the activity chronicle's name"""
+    NAME
     """Bucket by the activity chronicle's priority"""
     PRIORITY
     """Bucket by the activity chronicle's status"""
     STATUS
     """Bucket by the activity chronicle's chronicle producer"""
     CHRONICLE_PRODUCER
-    """Bucket by the activity chronicle's site"""
+    """Bucket by the activity chronicle's sites. An activity can have multiple sites, so one activity may be counted in multiple buckets."""
     SITE
-    """Bucket by the activity chronicle's data source"""
+    """Bucket by the activity chronicle's data sources. An activity can have multiple data sources, so one activity may be counted in multiple buckets."""
     DATA_SOURCE
+    """Bucket by the activity chronicle's labels. An activity can have multiple labels, so one activity may be counted in multiple buckets."""
+    LABEL
     """Bucket by the activity chronicle's validation status"""
     VALIDATION_STATUS
     """Bucket by the activity chronicle's approval status"""

--- a/java/src/main/java/io/worlds/api/model/ActivityChronicleSummaryBucketField.java
+++ b/java/src/main/java/io/worlds/api/model/ActivityChronicleSummaryBucketField.java
@@ -6,6 +6,10 @@ package io.worlds.api.model;
 public enum ActivityChronicleSummaryBucketField {
 
     /**
+     * Bucket by the activity chronicle's name
+     */
+    NAME("NAME"),
+    /**
      * Bucket by the activity chronicle's priority
      */
     PRIORITY("PRIORITY"),
@@ -18,13 +22,17 @@ public enum ActivityChronicleSummaryBucketField {
      */
     CHRONICLE_PRODUCER("CHRONICLE_PRODUCER"),
     /**
-     * Bucket by the activity chronicle's site
+     * Bucket by the activity chronicle's sites. An activity can have multiple sites, so one activity may be counted in multiple buckets.
      */
     SITE("SITE"),
     /**
-     * Bucket by the activity chronicle's data source
+     * Bucket by the activity chronicle's data sources. An activity can have multiple data sources, so one activity may be counted in multiple buckets.
      */
     DATA_SOURCE("DATA_SOURCE"),
+    /**
+     * Bucket by the activity chronicle's labels. An activity can have multiple labels, so one activity may be counted in multiple buckets.
+     */
+    LABEL("LABEL"),
     /**
      * Bucket by the activity chronicle's validation status
      */

--- a/java/src/main/java/io/worlds/api/model/ActivityChronicleSummaryBucketKey.java
+++ b/java/src/main/java/io/worlds/api/model/ActivityChronicleSummaryBucketKey.java
@@ -52,13 +52,13 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
     }
 
     /**
-     * The label of the activity chronicles in the summary bucket.
+     * The name of the activity chronicles in the summary bucket.
      */
     public String getName() {
         return name;
     }
     /**
-     * The label of the activity chronicles in the summary bucket.
+     * The name of the activity chronicles in the summary bucket.
      */
     public void setName(String name) {
         this.name = name;
@@ -239,7 +239,7 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
         }
 
         /**
-         * The label of the activity chronicles in the summary bucket.
+         * The name of the activity chronicles in the summary bucket.
          */
         public Builder setName(String name) {
             this.name = name;

--- a/java/src/main/java/io/worlds/api/model/ActivityChronicleSummaryBucketKey.java
+++ b/java/src/main/java/io/worlds/api/model/ActivityChronicleSummaryBucketKey.java
@@ -10,11 +10,13 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
     private static final long serialVersionUID = 1L;
 
     private java.time.OffsetDateTime time;
+    private String name;
     private String priority;
     private String status;
     private ChronicleProducer chronicleProducer;
     private Site site;
     private DataSource dataSource;
+    private String label;
     private String validationStatus;
     private String approvalStatus;
     private java.util.List<JSONFieldBucketKey> metadata;
@@ -22,13 +24,15 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
     public ActivityChronicleSummaryBucketKey() {
     }
 
-    public ActivityChronicleSummaryBucketKey(java.time.OffsetDateTime time, String priority, String status, ChronicleProducer chronicleProducer, Site site, DataSource dataSource, String validationStatus, String approvalStatus, java.util.List<JSONFieldBucketKey> metadata) {
+    public ActivityChronicleSummaryBucketKey(java.time.OffsetDateTime time, String name, String priority, String status, ChronicleProducer chronicleProducer, Site site, DataSource dataSource, String label, String validationStatus, String approvalStatus, java.util.List<JSONFieldBucketKey> metadata) {
         this.time = time;
+        this.name = name;
         this.priority = priority;
         this.status = status;
         this.chronicleProducer = chronicleProducer;
         this.site = site;
         this.dataSource = dataSource;
+        this.label = label;
         this.validationStatus = validationStatus;
         this.approvalStatus = approvalStatus;
         this.metadata = metadata;
@@ -45,6 +49,19 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
      */
     public void setTime(java.time.OffsetDateTime time) {
         this.time = time;
+    }
+
+    /**
+     * The label of the activity chronicles in the summary bucket.
+     */
+    public String getName() {
+        return name;
+    }
+    /**
+     * The label of the activity chronicles in the summary bucket.
+     */
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**
@@ -113,6 +130,19 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
     }
 
     /**
+     * The label of the activity chronicles in the summary bucket.
+     */
+    public String getLabel() {
+        return label;
+    }
+    /**
+     * The label of the activity chronicles in the summary bucket.
+     */
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    /**
      * The `validationStatus` of the activity chronicles in the summary bucket.
      */
     public String getValidationStatus() {
@@ -161,11 +191,13 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
         }
         final ActivityChronicleSummaryBucketKey that = (ActivityChronicleSummaryBucketKey) obj;
         return Objects.equals(time, that.time)
+            && Objects.equals(name, that.name)
             && Objects.equals(priority, that.priority)
             && Objects.equals(status, that.status)
             && Objects.equals(chronicleProducer, that.chronicleProducer)
             && Objects.equals(site, that.site)
             && Objects.equals(dataSource, that.dataSource)
+            && Objects.equals(label, that.label)
             && Objects.equals(validationStatus, that.validationStatus)
             && Objects.equals(approvalStatus, that.approvalStatus)
             && Objects.equals(metadata, that.metadata);
@@ -173,7 +205,7 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(time, priority, status, chronicleProducer, site, dataSource, validationStatus, approvalStatus, metadata);
+        return Objects.hash(time, name, priority, status, chronicleProducer, site, dataSource, label, validationStatus, approvalStatus, metadata);
     }
 
 
@@ -184,11 +216,13 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
     public static class Builder {
 
         private java.time.OffsetDateTime time;
+        private String name;
         private String priority;
         private String status;
         private ChronicleProducer chronicleProducer;
         private Site site;
         private DataSource dataSource;
+        private String label;
         private String validationStatus;
         private String approvalStatus;
         private java.util.List<JSONFieldBucketKey> metadata;
@@ -201,6 +235,14 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
          */
         public Builder setTime(java.time.OffsetDateTime time) {
             this.time = time;
+            return this;
+        }
+
+        /**
+         * The label of the activity chronicles in the summary bucket.
+         */
+        public Builder setName(String name) {
+            this.name = name;
             return this;
         }
 
@@ -245,6 +287,14 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
         }
 
         /**
+         * The label of the activity chronicles in the summary bucket.
+         */
+        public Builder setLabel(String label) {
+            this.label = label;
+            return this;
+        }
+
+        /**
          * The `validationStatus` of the activity chronicles in the summary bucket.
          */
         public Builder setValidationStatus(String validationStatus) {
@@ -270,7 +320,7 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
 
 
         public ActivityChronicleSummaryBucketKey build() {
-            return new ActivityChronicleSummaryBucketKey(time, priority, status, chronicleProducer, site, dataSource, validationStatus, approvalStatus, metadata);
+            return new ActivityChronicleSummaryBucketKey(time, name, priority, status, chronicleProducer, site, dataSource, label, validationStatus, approvalStatus, metadata);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/FilterActivityChronicleSummaryInput.java
+++ b/java/src/main/java/io/worlds/api/model/FilterActivityChronicleSummaryInput.java
@@ -15,6 +15,7 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
     private org.springframework.graphql.data.ArgumentValue<FilterIDInput> chronicleProducerId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterIDListInput> dataSourceIds = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterIDListInput> siteIds = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<FilterStringListInput> labels = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> priority = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> status = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterChronicleValidationStatusInput> validationStatus = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -27,12 +28,13 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
     public FilterActivityChronicleSummaryInput() {
     }
 
-    public FilterActivityChronicleSummaryInput(org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> startTime, org.springframework.graphql.data.ArgumentValue<FilterStringInput> name, org.springframework.graphql.data.ArgumentValue<FilterIDInput> chronicleProducerId, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> dataSourceIds, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> siteIds, org.springframework.graphql.data.ArgumentValue<FilterStringInput> priority, org.springframework.graphql.data.ArgumentValue<FilterStringInput> status, org.springframework.graphql.data.ArgumentValue<FilterChronicleValidationStatusInput> validationStatus, org.springframework.graphql.data.ArgumentValue<FilterStringInput> approvalStatus, org.springframework.graphql.data.ArgumentValue<FilterJSONFieldStringInput> metadata, java.util.List<FilterActivityChronicleSummaryInput> and, java.util.List<FilterActivityChronicleSummaryInput> or, org.springframework.graphql.data.ArgumentValue<FilterActivityChronicleSummaryInput> not) {
+    public FilterActivityChronicleSummaryInput(org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> startTime, org.springframework.graphql.data.ArgumentValue<FilterStringInput> name, org.springframework.graphql.data.ArgumentValue<FilterIDInput> chronicleProducerId, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> dataSourceIds, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> siteIds, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> labels, org.springframework.graphql.data.ArgumentValue<FilterStringInput> priority, org.springframework.graphql.data.ArgumentValue<FilterStringInput> status, org.springframework.graphql.data.ArgumentValue<FilterChronicleValidationStatusInput> validationStatus, org.springframework.graphql.data.ArgumentValue<FilterStringInput> approvalStatus, org.springframework.graphql.data.ArgumentValue<FilterJSONFieldStringInput> metadata, java.util.List<FilterActivityChronicleSummaryInput> and, java.util.List<FilterActivityChronicleSummaryInput> or, org.springframework.graphql.data.ArgumentValue<FilterActivityChronicleSummaryInput> not) {
         this.startTime = startTime;
         this.name = name;
         this.chronicleProducerId = chronicleProducerId;
         this.dataSourceIds = dataSourceIds;
         this.siteIds = siteIds;
+        this.labels = labels;
         this.priority = priority;
         this.status = status;
         this.validationStatus = validationStatus;
@@ -76,6 +78,13 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
     }
     public void setSiteIds(org.springframework.graphql.data.ArgumentValue<FilterIDListInput> siteIds) {
         this.siteIds = siteIds;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<FilterStringListInput> getLabels() {
+        return labels;
+    }
+    public void setLabels(org.springframework.graphql.data.ArgumentValue<FilterStringListInput> labels) {
+        this.labels = labels;
     }
 
     public org.springframework.graphql.data.ArgumentValue<FilterStringInput> getPriority() {
@@ -148,6 +157,7 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
             && Objects.equals(chronicleProducerId, that.chronicleProducerId)
             && Objects.equals(dataSourceIds, that.dataSourceIds)
             && Objects.equals(siteIds, that.siteIds)
+            && Objects.equals(labels, that.labels)
             && Objects.equals(priority, that.priority)
             && Objects.equals(status, that.status)
             && Objects.equals(validationStatus, that.validationStatus)
@@ -160,7 +170,7 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
 
     @Override
     public int hashCode() {
-        return Objects.hash(startTime, name, chronicleProducerId, dataSourceIds, siteIds, priority, status, validationStatus, approvalStatus, metadata, and, or, not);
+        return Objects.hash(startTime, name, chronicleProducerId, dataSourceIds, siteIds, labels, priority, status, validationStatus, approvalStatus, metadata, and, or, not);
     }
 
 
@@ -175,6 +185,7 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
         private org.springframework.graphql.data.ArgumentValue<FilterIDInput> chronicleProducerId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterIDListInput> dataSourceIds = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterIDListInput> siteIds = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<FilterStringListInput> labels = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> priority = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> status = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterChronicleValidationStatusInput> validationStatus = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -209,6 +220,11 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
 
         public Builder setSiteIds(org.springframework.graphql.data.ArgumentValue<FilterIDListInput> siteIds) {
             this.siteIds = siteIds;
+            return this;
+        }
+
+        public Builder setLabels(org.springframework.graphql.data.ArgumentValue<FilterStringListInput> labels) {
+            this.labels = labels;
             return this;
         }
 
@@ -254,7 +270,7 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
 
 
         public FilterActivityChronicleSummaryInput build() {
-            return new FilterActivityChronicleSummaryInput(startTime, name, chronicleProducerId, dataSourceIds, siteIds, priority, status, validationStatus, approvalStatus, metadata, and, or, not);
+            return new FilterActivityChronicleSummaryInput(startTime, name, chronicleProducerId, dataSourceIds, siteIds, labels, priority, status, validationStatus, approvalStatus, metadata, and, or, not);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/GeofenceEvent.java
+++ b/java/src/main/java/io/worlds/api/model/GeofenceEvent.java
@@ -88,11 +88,11 @@ public class GeofenceEvent implements java.io.Serializable {
 
     /**
      * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `tag` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
-    Use [track's tag]({{Types.Track}}) instead.
+and `tag` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+Use [track's tag]({{Types.Track}}) instead.
 
-    The class label of the object that triggered the geofence event, i.e person,
-    car, truck, etc.
+The class label of the object that triggered the geofence event, i.e person,
+car, truck, etc.
      */
     @Deprecated
     public String getTag() {
@@ -100,11 +100,11 @@ public class GeofenceEvent implements java.io.Serializable {
     }
     /**
      * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `tag` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
-    Use [track's tag]({{Types.Track}}) instead.
+and `tag` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+Use [track's tag]({{Types.Track}}) instead.
 
-    The class label of the object that triggered the geofence event, i.e person,
-    car, truck, etc.
+The class label of the object that triggered the geofence event, i.e person,
+car, truck, etc.
      */
     @Deprecated
     public void setTag(String tag) {
@@ -113,11 +113,11 @@ public class GeofenceEvent implements java.io.Serializable {
 
     /**
      * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `type` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+and `type` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
 
-    The type of geofence event, i.e ingress (an object entered the geofence), dwell
-    (an object remained in the geofence), and egress. (an object exited the
-    geofence)
+The type of geofence event, i.e ingress (an object entered the geofence), dwell
+(an object remained in the geofence), and egress. (an object exited the
+geofence)
      */
     @Deprecated
     public ActivityType getType() {
@@ -125,11 +125,11 @@ public class GeofenceEvent implements java.io.Serializable {
     }
     /**
      * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `type` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+and `type` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
 
-    The type of geofence event, i.e ingress (an object entered the geofence), dwell
-    (an object remained in the geofence), and egress. (an object exited the
-    geofence)
+The type of geofence event, i.e ingress (an object entered the geofence), dwell
+(an object remained in the geofence), and egress. (an object exited the
+geofence)
      */
     @Deprecated
     public void setType(ActivityType type) {
@@ -138,10 +138,10 @@ public class GeofenceEvent implements java.io.Serializable {
 
     /**
      * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `position` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+and `position` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
 
-    The GeoJSON point for the position of the track at the time of the geofence
-    event.
+The GeoJSON point for the position of the track at the time of the geofence
+event.
      */
     @Deprecated
     public GeoJSONPoint getPosition() {
@@ -149,10 +149,10 @@ public class GeofenceEvent implements java.io.Serializable {
     }
     /**
      * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `position` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+and `position` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
 
-    The GeoJSON point for the position of the track at the time of the geofence
-    event.
+The GeoJSON point for the position of the track at the time of the geofence
+event.
      */
     @Deprecated
     public void setPosition(GeoJSONPoint position) {
@@ -161,10 +161,10 @@ public class GeofenceEvent implements java.io.Serializable {
 
     /**
      * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `timestamp` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
-    Use [`startTime`]({{Types.GeofenceIntersection}}) and [`endTime`]({{Types.GeofenceIntersection}}) instead.
+and `timestamp` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+Use [`startTime`]({{Types.GeofenceIntersection}}) and [`endTime`]({{Types.GeofenceIntersection}}) instead.
 
-    The timestamp at which the event occurred.
+The timestamp at which the event occurred.
      */
     @Deprecated
     public java.time.OffsetDateTime getTimestamp() {
@@ -172,10 +172,10 @@ public class GeofenceEvent implements java.io.Serializable {
     }
     /**
      * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `timestamp` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
-    Use [`startTime`]({{Types.GeofenceIntersection}}) and [`endTime`]({{Types.GeofenceIntersection}}) instead.
+and `timestamp` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+Use [`startTime`]({{Types.GeofenceIntersection}}) and [`endTime`]({{Types.GeofenceIntersection}}) instead.
 
-    The timestamp at which the event occurred.
+The timestamp at which the event occurred.
      */
     @Deprecated
     public void setTimestamp(java.time.OffsetDateTime timestamp) {
@@ -184,9 +184,9 @@ public class GeofenceEvent implements java.io.Serializable {
 
     /**
      * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `metadata` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+and `metadata` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
 
-    Any additional information about the event will be stored here.
+Any additional information about the event will be stored here.
      */
     @Deprecated
     public java.lang.Object getMetadata() {
@@ -194,9 +194,9 @@ public class GeofenceEvent implements java.io.Serializable {
     }
     /**
      * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `metadata` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+and `metadata` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
 
-    Any additional information about the event will be stored here.
+Any additional information about the event will be stored here.
      */
     @Deprecated
     public void setMetadata(java.lang.Object metadata) {
@@ -272,11 +272,11 @@ public class GeofenceEvent implements java.io.Serializable {
 
         /**
          * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `tag` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
-    Use [track's tag]({{Types.Track}}) instead.
+and `tag` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+Use [track's tag]({{Types.Track}}) instead.
 
-    The class label of the object that triggered the geofence event, i.e person,
-    car, truck, etc.
+The class label of the object that triggered the geofence event, i.e person,
+car, truck, etc.
          */
         @Deprecated
         public Builder setTag(String tag) {
@@ -286,11 +286,11 @@ public class GeofenceEvent implements java.io.Serializable {
 
         /**
          * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `type` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+and `type` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
 
-    The type of geofence event, i.e ingress (an object entered the geofence), dwell
-    (an object remained in the geofence), and egress. (an object exited the
-    geofence)
+The type of geofence event, i.e ingress (an object entered the geofence), dwell
+(an object remained in the geofence), and egress. (an object exited the
+geofence)
          */
         @Deprecated
         public Builder setType(ActivityType type) {
@@ -300,10 +300,10 @@ public class GeofenceEvent implements java.io.Serializable {
 
         /**
          * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `position` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+and `position` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
 
-    The GeoJSON point for the position of the track at the time of the geofence
-    event.
+The GeoJSON point for the position of the track at the time of the geofence
+event.
          */
         @Deprecated
         public Builder setPosition(GeoJSONPoint position) {
@@ -313,10 +313,10 @@ public class GeofenceEvent implements java.io.Serializable {
 
         /**
          * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `timestamp` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
-    Use [`startTime`]({{Types.GeofenceIntersection}}) and [`endTime`]({{Types.GeofenceIntersection}}) instead.
+and `timestamp` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+Use [`startTime`]({{Types.GeofenceIntersection}}) and [`endTime`]({{Types.GeofenceIntersection}}) instead.
 
-    The timestamp at which the event occurred.
+The timestamp at which the event occurred.
          */
         @Deprecated
         public Builder setTimestamp(java.time.OffsetDateTime timestamp) {
@@ -326,9 +326,9 @@ public class GeofenceEvent implements java.io.Serializable {
 
         /**
          * [`geofenceEvents`]({{Queries.geofenceIntersections}}) is deprecated in favor of [`geofenceIntersections`]({{Queries.geofenceIntersections}}),
-    and `metadata` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
+and `metadata` will not be present on [`GeofenceIntersection`]({{Types.GeofenceIntersection}}).
 
-    Any additional information about the event will be stored here.
+Any additional information about the event will be stored here.
          */
         @Deprecated
         public Builder setMetadata(java.lang.Object metadata) {


### PR DESCRIPTION
## Description of Changes
Add bucket by `NAME` and `LABEL` to activity chronicle summary buckets.

Add filter by `label` to activity chronicle summaries.

## Link to Related Jira Ticket
[CE-5193]

[CE-5193]: https://worlds-io.atlassian.net/browse/CE-5193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ