### PR TITLE
CE-5356: Deprecate events

### DIFF
--- a/graphql/api/domains/chronicle/activity/activityChronicle.graphqls
+++ b/graphql/api/domains/chronicle/activity/activityChronicle.graphqls
@@ -35,7 +35,7 @@ type ActivityChronicle {
     """Clips associated with the activity."""
     dataSourceClips: [DataSourceClip!]!
     """Tracks associated with the activity."""
-    tracks: [Track!]
+    tracks: [Track!] @experimental(reason: "trackIds cannot yet be directly associated to activityChronicles.  Use metadata if specific track information is required.")
     """Sites associated with the activity."""
     sites: [Site!]
     """Data Sources associated with the activity."""
@@ -85,7 +85,7 @@ input CreateActivityChronicleInput {
     """Requests to create clips associated with the activity."""
     clips: [CreateClipInput!]
     """IDs for tracks to associate with the activity."""
-    trackIds: [ID!]
+    trackIds: [ID!] @experimental(reason: "trackIds cannot yet be directly associated to activityChronicles.  Use metadata if specific track information is required.")
     """IDs for sites to associate with the activity."""
     siteIds: [ID!]
     """IDs for data sources to associate with the activity."""
@@ -131,7 +131,7 @@ input UpdateActivityChronicleInput {
     """Requests to create clips associated with the activity."""
     clips: [CreateClipInput!]
     """IDs for tracks to associate with the activity."""
-    trackIds: [ID!]
+    trackIds: [ID!] @experimental(reason: "trackIds cannot yet be directly associated to activityChronicles.  Use metadata if specific track information is required.")
     """IDs for sites to associate with the activity."""
     siteIds: [ID!]
     """IDs for data sources to associate with the activity."""

--- a/graphql/api/domains/chronicle/activity/activityChronicle.graphqls
+++ b/graphql/api/domains/chronicle/activity/activityChronicle.graphqls
@@ -1,7 +1,7 @@
 """
 An activity chronicle represents behavior which occurs over a period of time.
 """
-type ActivityChronicle @experimental {
+type ActivityChronicle {
     """The unique identifier for the activity."""
     id: ID!
     """The chronicle producer that created the activity."""
@@ -53,7 +53,7 @@ type ActivityChronicle @experimental {
 """
 This input type is used to create a new [`ActivityChronicle`]({{Types.ActivityChronicle}}).
 """
-input CreateActivityChronicleInput @experimental {
+input CreateActivityChronicleInput {
     """The chronicle producer that owns the activity."""
     name: String!
     """The name of the activity"""
@@ -99,7 +99,7 @@ input CreateActivityChronicleInput @experimental {
 """
 This input type is used to update an existing [`ActivityChronicle`]({{Types.ActivityChronicle}}).
 """
-input UpdateActivityChronicleInput @experimental {
+input UpdateActivityChronicleInput {
     """The unique identifier of activity."""
     id: ID!
     """The name of the activity"""

--- a/graphql/api/domains/chronicle/activity/filter.graphqls
+++ b/graphql/api/domains/chronicle/activity/filter.graphqls
@@ -2,7 +2,7 @@
 FilterActivityChronicleInput filters [ActivityChronicles]({{Types.ActivityChronicle}}) based on criteria described below.
 Only one field should be provided per Filter object unless using an operator (`and` `or` `not`) as specified below.
 """
-input FilterActivityChronicleInput @experimental {
+input FilterActivityChronicleInput {
     """
     If provided, specifies filters that work against the `id` of the [`ActivityChronicle`]({{Types.ActivityChronicle}}).
     """

--- a/graphql/api/domains/chronicle/activity/mutation.graphqls
+++ b/graphql/api/domains/chronicle/activity/mutation.graphqls
@@ -5,10 +5,10 @@ extend type Mutation {
     createActivityChronicle(
         """Arguments to create a new event chronicle."""
         activityChronicle: CreateActivityChronicleInput!
-    ): ActivityChronicle! @experimental
+    ): ActivityChronicle!
     """Updates an existing [Event Chronicle]({{Types.EventChronicle}})."""
     updateActivityChronicle(
         """Arguments to update an existing event chronicle."""
         activityChronicle: UpdateActivityChronicleInput!
-    ): ActivityChronicle! @experimental
+    ): ActivityChronicle!
 }

--- a/graphql/api/domains/chronicle/activity/query.graphqls
+++ b/graphql/api/domains/chronicle/activity/query.graphqls
@@ -1,7 +1,7 @@
 """
 Indicates the field used for sorting an [`activityChronicles` query]({{Queries.activityChronicles}}).
 """
-enum ActivityChronicleSortField @experimental {
+enum ActivityChronicleSortField {
     """
     Sort the resulting list by the [`activityChronicle`]({{Types.ActivityChronicle}})'s unique identifier.
     """
@@ -31,7 +31,7 @@ enum ActivityChronicleSortField @experimental {
 """
 Indicates the field used for sorting an [`activityChronicles` query]({{Queries.activityChronicles}}).
 """
-input ActivityChronicleSort @experimental {
+input ActivityChronicleSort {
     """
     Any sortable field available to the ActivityChroniclesSortField. See the link to the
     type below for more details.
@@ -46,7 +46,7 @@ extend type Query {
     activityChronicle(
         """The activity's unique identifier."""
         id: ID!
-    ): ActivityChronicle @experimental
+    ): ActivityChronicle
     """Search for activities based on a set of filters."""
     activityChronicles(
         """Filter activities by unique identifier, type, time, etc."""
@@ -57,5 +57,5 @@ extend type Query {
         after: String,
         """The field and direction by which to sort the results"""
         sort: [ActivityChronicleSort!]! = [{field: START_TIME, direction: ASC}, {field: ID, direction: ASC}]
-    ): ActivityChronicleConnection @experimental
+    ): ActivityChronicleConnection
 }

--- a/graphql/api/domains/chronicle/activity/subscription.graphqls
+++ b/graphql/api/domains/chronicle/activity/subscription.graphqls
@@ -2,7 +2,7 @@
 FilterActivityChronicleInput filters [ActivityChronicles]({{Types.ActivityChronicle}}) based on criteria described below.
 Only one field should be provided per Filter object unless using an operator (`and` `or` `not`) as specified below.
 """
-input FilterActivityChronicleInputSubscription @experimental {
+input FilterActivityChronicleInputSubscription {
     """
     If provided, specifies filters that work against the `id` of the [`ActivityChronicle`]({{Types.ActivityChronicle}}).
     """
@@ -85,5 +85,5 @@ extend type Subscription {
         """
         Filter events by unique identifier of the event producer or type of event, etc.
         """filter: FilterActivityChronicleInputSubscription
-    ): ActivityChronicle! @experimental
+    ): ActivityChronicle!
 }

--- a/graphql/api/domains/chronicle/activity/util.graphqls
+++ b/graphql/api/domains/chronicle/activity/util.graphqls
@@ -2,7 +2,7 @@
 An `ActivityConnection` is the paginated results of an [`activities` query]({{Queries.activityChronicles}}).
 See [about queries](/guides/types/#queries) for details on how "connection" and "edge" types are used with pagination.
 """
-type ActivityChronicleConnection @experimental {
+type ActivityChronicleConnection {
     """Pagination information for the resulting edges."""
     edges: [ActivityChronicleEdge!]!
     """The resulting collection of activity edges."""
@@ -13,7 +13,7 @@ type ActivityChronicleConnection @experimental {
 An activity edge is the pairing of an [Activity]({{Types.Activity}}) with its query cursor.
 See [about queries](/guides/types/#queries) for details on how "connection" and "edge" types are used with pagination.
 """
-type ActivityChronicleEdge @experimental {
+type ActivityChronicleEdge {
     """Information about a particular [Activity]({{Types.Activity}})."""
     node: ActivityChronicle!
     """

--- a/graphql/api/domains/chronicle/chronicle.graphqls
+++ b/graphql/api/domains/chronicle/chronicle.graphqls
@@ -1,7 +1,7 @@
 """
 Used in [ChronicleValidationInput]({{Types.ChronicleValidationInput}}) to indicate whether an chronicle is `VALID` or `INVALID`.
 """
-enum ChronicleValidationStatus @experimental {
+enum ChronicleValidationStatus {
     """The chronicle is valid."""
     VALID
     """The chronicle is invalid."""
@@ -11,7 +11,7 @@ enum ChronicleValidationStatus @experimental {
 """
 This input type indicates whether an chronicle is valid and contains additional information about the validation.
 """
-type ChronicleValidation @experimental {
+type ChronicleValidation {
     """Whether the chronicle is `VALID` or `INVALID`."""
     status: ChronicleValidationStatus!
     """
@@ -30,7 +30,7 @@ detections and geofences. For instance, an chronicle producer could track detect
 hazards and people, creating an event chronicle for each case where a person was too close
 to a hazard without personal protective equipment.
 """
-type ChronicleProducer @experimental {
+type ChronicleProducer {
     """The unique identifier for the chronicle producer."""
     id: ID!
     """The name of the chronicle producer."""
@@ -50,7 +50,7 @@ type ChronicleProducer @experimental {
 """
 This input type is used to create a new custom [`ChronicleProducer`]({{Types.ChronicleProducer}}).
 """
-input CreateChronicleProducerInput @experimental {
+input CreateChronicleProducerInput {
     """The name of the chronicle producer."""
     name: String!
     """The text description of the chronicle producer."""
@@ -70,7 +70,7 @@ input CreateChronicleProducerInput @experimental {
 """
 This input type is used to update an existing [`ChronicleProducer`]({{Types.ChronicleProducer}}).
 """
-input UpdateChronicleProducerInput @experimental {
+input UpdateChronicleProducerInput {
     """The unique identifier for the chronicle producer."""
     id: ID!
     """The name of the chronicle producer."""
@@ -90,7 +90,7 @@ input UpdateChronicleProducerInput @experimental {
 """
 This input type indicates whether an chronicle is valid and contains additional information about the validation.
 """
-input ChronicleValidationInput @experimental {
+input ChronicleValidationInput {
     """Whether the chronicle is `VALID` or `INVALID`."""
     status: ChronicleValidationStatus!
     """

--- a/graphql/api/domains/chronicle/event/eventChronicle.graphqls
+++ b/graphql/api/domains/chronicle/event/eventChronicle.graphqls
@@ -1,7 +1,7 @@
 """
 An event chronicle represents an occurrence at a single point at time.
 """
-type EventChronicle @experimental {
+type EventChronicle {
     """The unique identifier for the event."""
     id: ID!
     """The chronicle producer that created the event."""
@@ -37,7 +37,7 @@ type EventChronicle @experimental {
 """
 This input type is used to create a new [`EventChronicle`]({{Types.EventChronicle}}).
 """
-input CreateEventChronicleInput @experimental {
+input CreateEventChronicleInput {
     """The name of the event"""
     name: String!
     """The event producer that owns the event."""
@@ -67,7 +67,7 @@ input CreateEventChronicleInput @experimental {
 """
 This input type is used to update an existing [`EventChronicle`]({{Types.EventChronicle}}).
 """
-input UpdateEventChronicleInput @experimental {
+input UpdateEventChronicleInput {
     """The unique identifier for the event."""
     id: ID!
     """The name of the event"""

--- a/graphql/api/domains/chronicle/event/filter.graphqls
+++ b/graphql/api/domains/chronicle/event/filter.graphqls
@@ -2,7 +2,7 @@
 FilterEventChronicleInput filters [EventChronicles]({{Types.EventChronicle}}) based on criteria described below.
 Only one field should be provided per Filter object unless using an operator (`and` `or` `not`) as specified below.
 """
-input FilterEventChronicleInput @experimental {
+input FilterEventChronicleInput {
     """
     If provided, specifies filters that work against the `id` of the [`EventChronicle`]({{Types.EventChronicle}}).
     """

--- a/graphql/api/domains/chronicle/event/mutation.graphqls
+++ b/graphql/api/domains/chronicle/event/mutation.graphqls
@@ -5,10 +5,10 @@ extend type Mutation {
     createEventChronicle(
         """Arguments to create a new event chronicle."""
         eventChronicle: CreateEventChronicleInput!
-    ): EventChronicle! @experimental
+    ): EventChronicle!
     """Updates an existing [Event Chronicle]({{Types.EventChronicle}})."""
     updateEventChronicle(
         """Arguments to update an existing event chronicle."""
         eventChronicle: UpdateEventChronicleInput!
-    ): EventChronicle! @experimental
+    ): EventChronicle!
 }

--- a/graphql/api/domains/chronicle/event/query.graphqls
+++ b/graphql/api/domains/chronicle/event/query.graphqls
@@ -1,7 +1,7 @@
 """
 Indicates the field used for sorting an [`eventChronicles` query]({{Queries.eventChronicles}}).
 """
-enum EventChronicleSortField @experimental {
+enum EventChronicleSortField {
     """
     Sort the resulting list by the [`eventChronicle`]({{Types.EventChronicle}})'s unique identifier.
     """
@@ -27,7 +27,7 @@ enum EventChronicleSortField @experimental {
 """
 Indicates the field used for sorting an [`eventChronicles` query]({{Queries.eventChronicles}}).
 """
-input EventChronicleSort @experimental {
+input EventChronicleSort {
     """
     Any sortable field available to the EventChroniclesSortField. See the link to the
     type below for more details.
@@ -42,7 +42,7 @@ extend type Query {
     eventChronicle(
         """The event's unique identifier."""
         id: ID!
-    ): EventChronicle @experimental
+    ): EventChronicle
     """Search for events based on a set of filters."""
     eventChronicles(
         """Filter events by unique identifier, type, time, etc."""
@@ -53,5 +53,5 @@ extend type Query {
         after: String,
         """The field and direction by which to sort the results"""
         sort: [EventChronicleSort!]! = [{field: TIMESTAMP, direction: ASC}, {field: ID, direction: ASC}]
-    ): EventChronicleConnection @experimental
+    ): EventChronicleConnection
 }

--- a/graphql/api/domains/chronicle/event/subscription.graphqls
+++ b/graphql/api/domains/chronicle/event/subscription.graphqls
@@ -2,7 +2,7 @@
 FilterEventChronicleInput filters [EventChronicles]({{Types.EventChronicle}}) based on criteria described below.
 Only one field should be provided per Filter object unless using an operator (`and` `or` `not`) as specified below.
 """
-input FilterEventChronicleInputSubscription @experimental {
+input FilterEventChronicleInputSubscription {
     """
     If provided, specifies filters that work against the `id` of the [`EventChronicle`]({{Types.EventChronicle}}).
     """
@@ -66,5 +66,5 @@ extend type Subscription {
         Filter events by unique identifier of the event producer or type of event, etc.
         """
         filter: FilterEventChronicleInputSubscription
-    ): EventChronicle! @experimental
+    ): EventChronicle!
 }

--- a/graphql/api/domains/chronicle/event/util.graphqls
+++ b/graphql/api/domains/chronicle/event/util.graphqls
@@ -2,7 +2,7 @@
 An `EventConnection` is the paginated results of an [`events` query]({{Queries.eventChronicles}}).
 See [about queries](/guides/types/#queries) for details on how "connection" and "edge" types are used with pagination.
 """
-type EventChronicleConnection @experimental {
+type EventChronicleConnection {
     """Pagination information for the resulting edges."""
     edges: [EventChronicleEdge!]!
     """The resulting collection of event edges."""
@@ -13,7 +13,7 @@ type EventChronicleConnection @experimental {
 An event edge is the pairing of an [Event]({{Types.Event}}) with its query cursor.
 See [about queries](/guides/types/#queries) for details on how "connection" and "edge" types are used with pagination.
 """
-type EventChronicleEdge @experimental {
+type EventChronicleEdge {
     """Information about a particular [Event]({{Types.Event}})."""
     node: EventChronicle!
     """

--- a/graphql/api/domains/chronicle/filter.graphqls
+++ b/graphql/api/domains/chronicle/filter.graphqls
@@ -2,7 +2,7 @@
 FilterChronicleProducerInput filters [ChronicleProducer]({{Types.ChronicleProducer}}) based on criteria described below.
 Only one field should be provided per Filter object unless using an operator (`and` `or` `not`) as specified below.
 """
-input FilterChronicleProducerInput @experimental {
+input FilterChronicleProducerInput {
     """
     If provided, specifies filters that work against the [ChronicleProducer]({{Types.ChronicleProducer}})'s unique id.
     """
@@ -31,7 +31,7 @@ input FilterChronicleProducerInput @experimental {
 """
 `FilterChronicleValidationStatusInput` allows for filtering based on an chronicle's validation status. Only one field should be provided per filter object.
 """
-input FilterChronicleValidationStatusInput @experimental {
+input FilterChronicleValidationStatusInput {
     """
     If provided, the chronicle's validation status must be equivalent to the value provided to match the current filter.
     """eq: ChronicleValidationStatus

--- a/graphql/api/domains/chronicle/mutation.graphqls
+++ b/graphql/api/domains/chronicle/mutation.graphqls
@@ -3,12 +3,12 @@ extend type Mutation {
     createChronicleProducer(
         """Arguments to create a new chronicle producer."""
         chronicleProducer: CreateChronicleProducerInput!
-    ): ChronicleProducer! @experimental
+    ): ChronicleProducer!
     """
     Updates an existing ChronicleProducer.
     """
     updateChronicleProducer(
         """Arguments to update an existing chronicle producer."""
         chronicleProducer: UpdateChronicleProducerInput!
-    ): ChronicleProducer! @experimental
+    ): ChronicleProducer!
 }

--- a/graphql/api/domains/chronicle/query.graphqls
+++ b/graphql/api/domains/chronicle/query.graphqls
@@ -1,7 +1,7 @@
 """
 Indicates the field used for sorting an [`chronicleProducers` query]({{Queries.chronicleProducers}}).
 """
-enum ChronicleProducersSortField @experimental {
+enum ChronicleProducersSortField {
     """
     Sort the resulting list by the [`ChronicleProducer`]({{Types.ChronicleProducer}})'s unique identifier.
     """
@@ -15,7 +15,7 @@ enum ChronicleProducersSortField @experimental {
 """
 ChronicleProducersSort allows for sorting an chronicle producer by a sort field and direction.
 """
-input ChronicleProducersSort @experimental {
+input ChronicleProducersSort {
     """
     Any sortable field available to the ChronicleProducersSortField. See the link to the
     type below for more details.
@@ -30,7 +30,7 @@ extend type Query {
     chronicleProducer(
         """The chronicle producer's unique identifier."""
         id: ID!
-    ): ChronicleProducer @experimental
+    ): ChronicleProducer
     """Search for chronicle producers based on a set of filters."""
     chronicleProducers(
         """Filter chronicle producers by unique identifier or name"""
@@ -41,5 +41,5 @@ extend type Query {
         after: String,
         """The field and direction by which to sort the results"""
         sort: [ChronicleProducersSort!]! = [{field: NAME, direction: ASC}, {field: ID, direction: ASC}]
-    ): ChronicleProducerConnection @experimental
+    ): ChronicleProducerConnection
 }

--- a/graphql/api/domains/chronicle/summary/filter.graphqls
+++ b/graphql/api/domains/chronicle/summary/filter.graphqls
@@ -2,7 +2,7 @@
 FilterSummaryChronicleInput filters [SummaryChronicles]({{Types.SummaryChronicle}}) based on criteria described below.
 Only one field should be provided per Filter object unless using an operator (`and` `or` `not`) as specified below.
 """
-input FilterSummaryChronicleInput @experimental {
+input FilterSummaryChronicleInput {
     """
     If provided, specifies filters that work against the `id` of the [`SummaryChronicle`]({{Types.SummaryChronicle}}).
     """

--- a/graphql/api/domains/chronicle/summary/mutation.graphqls
+++ b/graphql/api/domains/chronicle/summary/mutation.graphqls
@@ -5,10 +5,10 @@ extend type Mutation {
     createSummaryChronicle(
         """Arguments to create a new summary chronicle."""
         summaryChronicle: CreateSummaryChronicleInput!
-    ): SummaryChronicle! @experimental
+    ): SummaryChronicle!
     """Updates an existing [Summary Chronicle]({{Types.SummaryChronicle}})."""
     updateSummaryChronicle(
         """Arguments to update an existing summary chronicle."""
         summaryChronicle: UpdateSummaryChronicleInput!
-    ): SummaryChronicle! @experimental
+    ): SummaryChronicle!
 }

--- a/graphql/api/domains/chronicle/summary/query.graphqls
+++ b/graphql/api/domains/chronicle/summary/query.graphqls
@@ -1,7 +1,7 @@
 """
 Indicates the field used for sorting an [`summaryChronicles` query]({{Queries.summaryChronicles}}).
 """
-enum SummaryChronicleSortField @experimental {
+enum SummaryChronicleSortField {
     """
     Sort the resulting list by the [`summaryChronicle`]({{Types.SummaryChronicle}})'s unique identifier.
     """ID
@@ -29,7 +29,7 @@ enum SummaryChronicleSortField @experimental {
 """
 Indicates the field used for sorting a [`summaryChronicles` query]({{Queries.summaryChronicles}}).
 """
-input SummaryChronicleSort @experimental {
+input SummaryChronicleSort {
     """
     Any sortable field available to the SummaryChroniclesSortField. See the link to the
     type below for more details.
@@ -44,7 +44,7 @@ extend type Query {
     summaryChronicle(
         """The summary's unique identifier."""
         id: ID!
-    ): SummaryChronicle @experimental
+    ): SummaryChronicle
     """Search for summaries based on a set of filters."""
     summaryChronicles(
         """Filter summaries by unique identifier, type, time, etc."""
@@ -55,5 +55,5 @@ extend type Query {
         after: String,
         """The field and direction by which to sort the results"""
         sort: [SummaryChronicleSort!]! = [{field: START_TIME, direction: ASC}, {field: ID, direction: ASC}]
-    ): SummaryChronicleConnection @experimental
+    ): SummaryChronicleConnection
 }

--- a/graphql/api/domains/chronicle/summary/subscription.graphqls
+++ b/graphql/api/domains/chronicle/summary/subscription.graphqls
@@ -2,7 +2,7 @@
 FilterSummaryChronicleInput filters [SummaryChronicles]({{Types.SummaryChronicle}}) based on criteria described below.
 Only one field should be provided per Filter object unless using an operator (`and` `or` `not`) as specified below.
 """
-input FilterSummaryChronicleInputSubscription @experimental {
+input FilterSummaryChronicleInputSubscription {
     """
     If provided, specifies filters that work against the `id` of the [`SummaryChronicle`]({{Types.SummaryChronicle}}).
     """
@@ -70,5 +70,5 @@ extend type Subscription {
         Filter events by unique identifier of the event producer or type of event, etc.
         """
         filter: FilterSummaryChronicleInputSubscription
-    ): SummaryChronicle! @experimental
+    ): SummaryChronicle!
 }

--- a/graphql/api/domains/chronicle/summary/summaryChronicle.graphqls
+++ b/graphql/api/domains/chronicle/summary/summaryChronicle.graphqls
@@ -1,7 +1,7 @@
 """
 A summary chronicle summarizes across a specific timeframe.  It can reference event and activity chronicles.
 """
-type SummaryChronicle @experimental {
+type SummaryChronicle {
     """The unique identifier for the summary."""
     id: ID!
     """The name of the summary"""
@@ -41,7 +41,7 @@ type SummaryChronicle @experimental {
 """
 This input type is used to create a new [`SummaryChronicle`]({{Types.SummaryChronicle}}).
 """
-input CreateSummaryChronicleInput @experimental {
+input CreateSummaryChronicleInput {
     """The name of the summary"""
     name: String!
     """The summary producer that owns the summary."""
@@ -75,7 +75,7 @@ input CreateSummaryChronicleInput @experimental {
 """
 This input type is used to update an existing [`SummaryChronicle`]({{Types.SummaryChronicle}}).
 """
-input UpdateSummaryChronicleInput @experimental {
+input UpdateSummaryChronicleInput {
     """The unique identifier for the summary."""
     id: ID!
     """The name of the summary"""

--- a/graphql/api/domains/chronicle/summary/util.graphqls
+++ b/graphql/api/domains/chronicle/summary/util.graphqls
@@ -2,7 +2,7 @@
 An `SummaryConnection` is the paginated results of an [`summaries` query]({{Queries.summaryChronicles}}).
 See [about queries](/guides/types/#queries) for details on how "connection" and "edge" types are used with pagination.
 """
-type SummaryChronicleConnection @experimental {
+type SummaryChronicleConnection {
     """Pagination information for the resulting edges."""
     edges: [SummaryChronicleEdge!]!
     """The resulting collection of summary edges."""
@@ -13,7 +13,7 @@ type SummaryChronicleConnection @experimental {
 An summary edge is the pairing of an [Summary]({{Types.Summary}}) with its query cursor.
 See [about queries](/guides/types/#queries) for details on how "connection" and "edge" types are used with pagination.
 """
-type SummaryChronicleEdge @experimental {
+type SummaryChronicleEdge {
     """Information about a particular [Summary]({{Types.Summary}})."""
     node: SummaryChronicle!
     """

--- a/graphql/api/domains/chronicle/util.graphqls
+++ b/graphql/api/domains/chronicle/util.graphqls
@@ -2,7 +2,7 @@
 The paginated results of an [`chronicleProducers` query]({{Queries.chronicleProducers}}).
 See [about queries](/guides/types/#queries) for details on how "connection" and "edge" types are used with pagination.
 """
-type ChronicleProducerConnection @experimental {
+type ChronicleProducerConnection {
     """The resulting collection of chronicle producer edges."""
     edges: [ChronicleProducerEdge!]!
     """Pagination information for the resulting edges."""
@@ -13,7 +13,7 @@ type ChronicleProducerConnection @experimental {
 The pairing of an [ChronicleProducer]({{Types.ChronicleProducer}}) with its query cursor.
 See [about queries](/guides/types/#queries) for details on how "connection" and "edge" types are used with pagination.
 """
-type ChronicleProducerEdge @experimental {
+type ChronicleProducerEdge {
     """
     Information about a particular [ChronicleProducer]({{Types.ChronicleProducer}}).
     """

--- a/graphql/api/domains/events/mutation.graphqls
+++ b/graphql/api/domains/events/mutation.graphqls
@@ -3,24 +3,24 @@ extend type Mutation {
     createEventProducer(
         """Arguments to create a new event producer."""
         eventProducer: EventProducerInput!
-    ): EventProducer
+    ): EventProducer @deprecated(reason: "Use the Chronicles API instead. See `createChronicleProducer` mutation.")
     """
     Updates an existing EventProducer.
     """
     updateEventProducer(
         """Arguments to update an existing event producer."""
         eventProducer: UpdateEventProducerInput!
-    ): EventProducer
+    ): EventProducer @deprecated(reason: "Use the Chronicles API instead. See `updateChronicleProducer` mutation.")
     """
     Creates a new Event. This allows for the creation of custom events within the Worlds system.
     """
     createEvent(
         """Arguments to create a new event."""
         event: CreateEventInput!
-    ): Event
+    ): Event @deprecated(reason: "Use the Chronicles API instead. See `createActivityChronicle`, `createEventChronicle`, or `createSummaryChronicle` mutations.")
     """Updates an existing Event."""
     updateEvent(
         """Arguments to update an existing event."""
         event: UpdateEventInput!
-    ): Event
+    ): Event @deprecated(reason: "Use the Chronicles API instead. See `updateActivityChronicle`, `updateEventChronicle`, or `updateSummaryChronicle` mutations.")
 }

--- a/graphql/api/domains/events/query.graphqls
+++ b/graphql/api/domains/events/query.graphqls
@@ -55,7 +55,7 @@ extend type Query {
     eventProducer(
         """The event producer's unique identifier."""
         id: ID!
-    ): EventProducer
+    ): EventProducer @deprecated(reason: "Use the Chronicles API instead. See `chronicleProducer` query.")
     """Search for event producers based on a set of filters."""
     eventProducers(
         """Filter event producers by unique identifier or name"""
@@ -66,12 +66,12 @@ extend type Query {
         after: String
         """The field and direction by which to sort the results"""
         sort: [EventProducersSort!]! = [{field: EVENT_PRODUCER_NAME, direction: ASC}, {field: ID, direction: ASC}]
-    ): EventProducerConnection
+    ): EventProducerConnection @deprecated(reason: "Use the Chronicles API instead. See `chronicleProducers` query.")
     """Look up an event by its unique identifier."""
     event(
         """The event's unique identifier."""
         id: ID!
-    ): Event
+    ): Event @deprecated(reason: "Use the Chronicles API instead. See `activityChronicle`, `eventChronicle`, or `summaryChronicle` queries.")
     """Search for events based on a set of filters."""
     events(
         """Filter events by unique identifier, type, time, etc."""
@@ -82,5 +82,5 @@ extend type Query {
         after: String
         """The field and direction by which to sort the results"""
         sort: [EventsSort!]! = [{field: START_TIME, direction: ASC}, {field: ID, direction: ASC}]
-    ): EventConnection
+    ): EventConnection @deprecated(reason: "Use the Chronicles API instead. See `activityChronicles`, `eventChronicles`, or `summaryChronicles` queries.")
 }

--- a/graphql/api/domains/events/subscription.graphqls
+++ b/graphql/api/domains/events/subscription.graphqls
@@ -7,5 +7,5 @@ extend type Subscription {
         Filter events by unique identifier of the event producer or type of event, etc.
         """
         filter: FilterEventActivityInput
-    ): Event
+    ): Event @deprecated(reason: "Use the Chronicles API instead. See `activityChronicles`, `eventChronicles`, or `summaryChronicles` subscriptions.")
 }

--- a/graphql/api/root.graphqls
+++ b/graphql/api/root.graphqls
@@ -7,4 +7,6 @@ type Subscription
 """
 Indicates that the annotated type or field is experimental and may change in the future.  Documentation may not be provided for experimental types.
 """
-directive @experimental on INPUT_OBJECT | OBJECT | ENUM | FIELD_DEFINITION
+directive @experimental(
+    reason: String
+) on INPUT_OBJECT | INPUT_FIELD_DEFINITION | OBJECT | ENUM | FIELD_DEFINITION


### PR DESCRIPTION
## Description of Changes
Deprecate events in favor of chronicles.

Remove `@experimental` annotation from chronicles.  Keep an `@experimantal` annotation on `activityChronicle.trackIds`.

This will be released as a new major version to reflect the paradigm shift from events to chronicles.

## Link to Related Jira Ticket
[CE-5356]

[CE-5356]: https://worlds-io.atlassian.net/browse/CE-5356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ