### PR TITLE
CE-5349: Add timezone field to Site API model

### DIFF
--- a/graphql/api/domains/site/site.graphqls
+++ b/graphql/api/domains/site/site.graphqls
@@ -6,6 +6,8 @@ type Site {
     id: ID!
     """The name of the site."""
     name: String!
+    """The IANA timezone identifier for this site (e.g. 'America/New_York', 'Europe/London', 'UTC')."""
+    timezone: String!
     """The geographic location of the site"""
     position: GeoJSONPoint
     """The geographic shape of the site"""
@@ -24,6 +26,8 @@ Input type used to create a new [Site]({{Types.Site}.
 input CreateSiteInput {
     """The name of the site."""
     name: String!
+    """The IANA timezone identifier for this site (e.g. 'America/New_York'). Defaults to 'UTC' if not provided."""
+    timezone: String
     """The geographic location of the site"""
     position: GeoJSONPointInput
     """The geographic shape of the site"""
@@ -38,6 +42,8 @@ input UpdateSiteInput {
     id: ID!
     """The name of the site."""
     name: String
+    """The IANA timezone identifier for this site (e.g. 'America/New_York')."""
+    timezone: String
     """The geographic location of the site"""
     position: GeoJSONPointInput
     """The geographic shape of the site"""

--- a/graphql/api/domains/site/site.graphqls
+++ b/graphql/api/domains/site/site.graphqls
@@ -6,7 +6,7 @@ type Site {
     id: ID!
     """The name of the site."""
     name: String!
-    """The IANA timezone identifier for this site (e.g. 'America/New_York', 'Europe/London', 'UTC')."""
+    """The IANA timezone identifier for this site (e.g. 'America/New_York', 'UTC')."""
     timezone: String!
     """The geographic location of the site"""
     position: GeoJSONPoint

--- a/java/src/main/java/io/worlds/api/model/CreateSiteInput.java
+++ b/java/src/main/java/io/worlds/api/model/CreateSiteInput.java
@@ -11,14 +11,16 @@ public class CreateSiteInput implements java.io.Serializable {
 
     @jakarta.validation.constraints.NotNull
     private String name;
+    private org.springframework.graphql.data.ArgumentValue<String> timezone = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<GeoJSONMultiPolygonInput> polygon = org.springframework.graphql.data.ArgumentValue.omitted();
 
     public CreateSiteInput() {
     }
 
-    public CreateSiteInput(String name, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, org.springframework.graphql.data.ArgumentValue<GeoJSONMultiPolygonInput> polygon) {
+    public CreateSiteInput(String name, org.springframework.graphql.data.ArgumentValue<String> timezone, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, org.springframework.graphql.data.ArgumentValue<GeoJSONMultiPolygonInput> polygon) {
         this.name = name;
+        this.timezone = timezone;
         this.position = position;
         this.polygon = polygon;
     }
@@ -28,6 +30,13 @@ public class CreateSiteInput implements java.io.Serializable {
     }
     public void setName(String name) {
         this.name = name;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<String> getTimezone() {
+        return timezone;
+    }
+    public void setTimezone(org.springframework.graphql.data.ArgumentValue<String> timezone) {
+        this.timezone = timezone;
     }
 
     public org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> getPosition() {
@@ -54,13 +63,14 @@ public class CreateSiteInput implements java.io.Serializable {
         }
         final CreateSiteInput that = (CreateSiteInput) obj;
         return Objects.equals(name, that.name)
+            && Objects.equals(timezone, that.timezone)
             && Objects.equals(position, that.position)
             && Objects.equals(polygon, that.polygon);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, position, polygon);
+        return Objects.hash(name, timezone, position, polygon);
     }
 
 
@@ -71,6 +81,7 @@ public class CreateSiteInput implements java.io.Serializable {
     public static class Builder {
 
         private String name;
+        private org.springframework.graphql.data.ArgumentValue<String> timezone = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<GeoJSONMultiPolygonInput> polygon = org.springframework.graphql.data.ArgumentValue.omitted();
 
@@ -79,6 +90,11 @@ public class CreateSiteInput implements java.io.Serializable {
 
         public Builder setName(String name) {
             this.name = name;
+            return this;
+        }
+
+        public Builder setTimezone(org.springframework.graphql.data.ArgumentValue<String> timezone) {
+            this.timezone = timezone;
             return this;
         }
 
@@ -94,7 +110,7 @@ public class CreateSiteInput implements java.io.Serializable {
 
 
         public CreateSiteInput build() {
-            return new CreateSiteInput(name, position, polygon);
+            return new CreateSiteInput(name, timezone, position, polygon);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/Site.java
+++ b/java/src/main/java/io/worlds/api/model/Site.java
@@ -13,6 +13,8 @@ public class Site implements java.io.Serializable, UnifiedSearchNameResponseEnti
     private String id;
     @jakarta.validation.constraints.NotNull
     private String name;
+    @jakarta.validation.constraints.NotNull
+    private String timezone;
     private GeoJSONPoint position;
     private GeoJSONMultiPolygon polygon;
     @jakarta.validation.constraints.NotNull
@@ -25,9 +27,10 @@ public class Site implements java.io.Serializable, UnifiedSearchNameResponseEnti
     public Site() {
     }
 
-    public Site(String id, String name, GeoJSONPoint position, GeoJSONMultiPolygon polygon, java.util.List<Device> devices, java.util.List<PointOfInterest> pointsOfInterest, java.util.List<Geofence> geofences) {
+    public Site(String id, String name, String timezone, GeoJSONPoint position, GeoJSONMultiPolygon polygon, java.util.List<Device> devices, java.util.List<PointOfInterest> pointsOfInterest, java.util.List<Geofence> geofences) {
         this.id = id;
         this.name = name;
+        this.timezone = timezone;
         this.position = position;
         this.polygon = polygon;
         this.devices = devices;
@@ -59,6 +62,19 @@ public class Site implements java.io.Serializable, UnifiedSearchNameResponseEnti
      */
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+     * The IANA timezone identifier for this site (e.g. 'America/New_York', 'Europe/London', 'UTC').
+     */
+    public String getTimezone() {
+        return timezone;
+    }
+    /**
+     * The IANA timezone identifier for this site (e.g. 'America/New_York', 'Europe/London', 'UTC').
+     */
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
     }
 
     /**
@@ -137,6 +153,7 @@ public class Site implements java.io.Serializable, UnifiedSearchNameResponseEnti
         final Site that = (Site) obj;
         return Objects.equals(id, that.id)
             && Objects.equals(name, that.name)
+            && Objects.equals(timezone, that.timezone)
             && Objects.equals(position, that.position)
             && Objects.equals(polygon, that.polygon)
             && Objects.equals(devices, that.devices)
@@ -146,7 +163,7 @@ public class Site implements java.io.Serializable, UnifiedSearchNameResponseEnti
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, position, polygon, devices, pointsOfInterest, geofences);
+        return Objects.hash(id, name, timezone, position, polygon, devices, pointsOfInterest, geofences);
     }
 
 
@@ -158,6 +175,7 @@ public class Site implements java.io.Serializable, UnifiedSearchNameResponseEnti
 
         private String id;
         private String name;
+        private String timezone;
         private GeoJSONPoint position;
         private GeoJSONMultiPolygon polygon;
         private java.util.List<Device> devices;
@@ -180,6 +198,14 @@ public class Site implements java.io.Serializable, UnifiedSearchNameResponseEnti
          */
         public Builder setName(String name) {
             this.name = name;
+            return this;
+        }
+
+        /**
+         * The IANA timezone identifier for this site (e.g. 'America/New_York', 'Europe/London', 'UTC').
+         */
+        public Builder setTimezone(String timezone) {
+            this.timezone = timezone;
             return this;
         }
 
@@ -225,7 +251,7 @@ public class Site implements java.io.Serializable, UnifiedSearchNameResponseEnti
 
 
         public Site build() {
-            return new Site(id, name, position, polygon, devices, pointsOfInterest, geofences);
+            return new Site(id, name, timezone, position, polygon, devices, pointsOfInterest, geofences);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/UpdateSiteInput.java
+++ b/java/src/main/java/io/worlds/api/model/UpdateSiteInput.java
@@ -12,15 +12,17 @@ public class UpdateSiteInput implements java.io.Serializable {
     @jakarta.validation.constraints.NotNull
     private String id;
     private org.springframework.graphql.data.ArgumentValue<String> name = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<String> timezone = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<GeoJSONMultiPolygonInput> polygon = org.springframework.graphql.data.ArgumentValue.omitted();
 
     public UpdateSiteInput() {
     }
 
-    public UpdateSiteInput(String id, org.springframework.graphql.data.ArgumentValue<String> name, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, org.springframework.graphql.data.ArgumentValue<GeoJSONMultiPolygonInput> polygon) {
+    public UpdateSiteInput(String id, org.springframework.graphql.data.ArgumentValue<String> name, org.springframework.graphql.data.ArgumentValue<String> timezone, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, org.springframework.graphql.data.ArgumentValue<GeoJSONMultiPolygonInput> polygon) {
         this.id = id;
         this.name = name;
+        this.timezone = timezone;
         this.position = position;
         this.polygon = polygon;
     }
@@ -37,6 +39,13 @@ public class UpdateSiteInput implements java.io.Serializable {
     }
     public void setName(org.springframework.graphql.data.ArgumentValue<String> name) {
         this.name = name;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<String> getTimezone() {
+        return timezone;
+    }
+    public void setTimezone(org.springframework.graphql.data.ArgumentValue<String> timezone) {
+        this.timezone = timezone;
     }
 
     public org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> getPosition() {
@@ -64,13 +73,14 @@ public class UpdateSiteInput implements java.io.Serializable {
         final UpdateSiteInput that = (UpdateSiteInput) obj;
         return Objects.equals(id, that.id)
             && Objects.equals(name, that.name)
+            && Objects.equals(timezone, that.timezone)
             && Objects.equals(position, that.position)
             && Objects.equals(polygon, that.polygon);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, position, polygon);
+        return Objects.hash(id, name, timezone, position, polygon);
     }
 
 
@@ -82,6 +92,7 @@ public class UpdateSiteInput implements java.io.Serializable {
 
         private String id;
         private org.springframework.graphql.data.ArgumentValue<String> name = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<String> timezone = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<GeoJSONMultiPolygonInput> polygon = org.springframework.graphql.data.ArgumentValue.omitted();
 
@@ -98,6 +109,11 @@ public class UpdateSiteInput implements java.io.Serializable {
             return this;
         }
 
+        public Builder setTimezone(org.springframework.graphql.data.ArgumentValue<String> timezone) {
+            this.timezone = timezone;
+            return this;
+        }
+
         public Builder setPosition(org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position) {
             this.position = position;
             return this;
@@ -110,7 +126,7 @@ public class UpdateSiteInput implements java.io.Serializable {
 
 
         public UpdateSiteInput build() {
-            return new UpdateSiteInput(id, name, position, polygon);
+            return new UpdateSiteInput(id, name, timezone, position, polygon);
         }
 
     }


### PR DESCRIPTION
## Summary
- Adds `timezone` field (IANA format, e.g. `America/New_York`) to `Site` type, `CreateSiteInput`, and `UpdateSiteInput` in the GraphQL schema and Java model classes
- `timezone` is required (`String!`) on the `Site` response type, optional on create/update inputs