### PR TITLE
CE-5398: Move bucketing strategy to query argument

### DIFF
--- a/graphql/api/domains/summary/query.graphqls
+++ b/graphql/api/domains/summary/query.graphqls
@@ -13,6 +13,8 @@ extend type Query {
         If provided, return [summary buckets]({{Types.TracksSummaryBucket}}) of this size.
         """
         bucket: SummaryBucketSize @deprecated(reason: "Bucket by `tracksBucket.size` instead.")
+        """How to bucket tracks.  Defaults to `ACTIVE`."""
+        bucketingStrategy: BucketingStrategy! = ACTIVE
         """
         If provided, group the summary buckets by the provided grouping types.
         """
@@ -30,6 +32,8 @@ extend type Query {
         If provided, return [summary buckets]({{Types.EventsSummaryBucket}}) of this size.
         """
         bucket: SummaryBucketSize @deprecated(reason: "Grouping by `buckets` is deprecated in favor of grouping by `eventsBucket`.  Use `eventsBucket.size` to group events by a `SummaryBucketSize`.")
+        """How to bucket events.  Defaults to `ACTIVE`."""
+        bucketingStrategy: BucketingStrategy! = ACTIVE
         """
         If provided, group the summary buckets by the provided grouping types.
         """
@@ -48,6 +52,8 @@ extend type Query {
         endTime: DateTimeOffset!
         """If provided, only summarize videos matching the filter."""
         filter: FilterVideosSummaryInput
+        """How to bucket videos.  Defaults to `ACTIVE`."""
+        bucketingStrategy: BucketingStrategy! = ACTIVE
         """
         If provided, group the summary buckets by the provided grouping types.
         """
@@ -61,6 +67,8 @@ extend type Query {
         endTime: DateTimeOffset!
         """If provided, only summarize activity chronicles matching the filter."""
         filter: FilterActivityChronicleSummaryInput
+        """How to bucket activity chronicles.  Defaults to `ACTIVE`."""
+        bucketingStrategy: BucketingStrategy! = ACTIVE
         """
         If provided, group the summary buckets by the provided grouping types.
         """
@@ -79,6 +87,8 @@ extend type Query {
         endTime: DateTimeOffset!
         """If provided, only summarize zone intersections matching the filter."""
         filter: FilterZoneIntersectionSummaryInput
+        """How to bucket zone intersections.  Defaults to `ACTIVE`."""
+        bucketingStrategy: BucketingStrategy! = ACTIVE
         """
         If provided, group the summary buckets by the provided grouping types.
         """

--- a/graphql/api/domains/summary/util.graphqls
+++ b/graphql/api/domains/summary/util.graphqls
@@ -62,7 +62,7 @@ input TracksSummaryBucketType {
     """If provided, group the summary buckets by time buckets of the provided size."""
     size: SummaryBucketSize
     """How to bucket tracks.  Defaults to `ACTIVE`."""
-    bucketingStrategy: BucketingStrategy
+    bucketingStrategy: BucketingStrategy @deprecated(reason: "bucketingStrategy is deprecated on TracksSummaryBucketType.  Instead, use the query parameter for bucketingStrategy to specify for both top-level and bucketed results.  If this field is provided, it will overwrite the query parameter.")
     """If provided, group the summary buckets by the values of the provided fields."""
     fields: [TracksSummaryBucketField!]
 }
@@ -92,7 +92,7 @@ input EventsSummaryBucketType {
     """If provided, group the summary buckets by time buckets of the provided size."""
     size: SummaryBucketSize
     """How to bucket event summaries.  Defaults to `ACTIVE`."""
-    bucketingStrategy: BucketingStrategy
+    bucketingStrategy: BucketingStrategy @deprecated(reason: "bucketingStrategy is deprecated on EventsSummaryBucketType.  Instead, use the query parameter for bucketingStrategy to specify for both top-level and bucketed results.  If this field is provided, it will overwrite the query parameter.")
     """If provided, group the summary buckets by the values of the provided fields."""
     fields: [EventsSummaryBucketField!]
     """If provided, group the summary buckets by the values of the provided metadata fields."""
@@ -148,7 +148,7 @@ input ActivityChronicleSummaryBucketType {
     """If provided, group the summary buckets by time buckets of the provided size."""
     size: SummaryBucketSize
     """How to bucket activity chronicles.  Defaults to `ACTIVE`."""
-    bucketingStrategy: BucketingStrategy
+    bucketingStrategy: BucketingStrategy @deprecated(reason: "bucketingStrategy is deprecated on ActivityChronicleSummaryBucketType.  Instead, use the query parameter for bucketingStrategy to specify for both top-level and bucketed results.  If this field is provided, it will overwrite the query parameter.")
     """If provided, group the summary buckets by the values of the provided fields."""
     fields: [ActivityChronicleSummaryBucketField!]
     """If provided, group the summary buckets by the values of the provided metadata fields."""
@@ -174,7 +174,7 @@ input ZoneIntersectionSummaryBucketType {
     """If provided, group the summary buckets by time buckets of the provided size."""
     size: SummaryBucketSize
     """How to bucket zone intersections.  Defaults to `ACTIVE`."""
-    bucketingStrategy: BucketingStrategy
+    bucketingStrategy: BucketingStrategy @deprecated(reason: "bucketingStrategy is deprecated on ZoneIntersectionSummaryBucketType.  Instead, use the query parameter for bucketingStrategy to specify for both top-level and bucketed results.  If this field is provided, it will overwrite the query parameter.")
     """If provided, group the summary buckets by the values of the provided fields."""
     fields: [ZoneIntersectionSummaryBucketField!]
 }

--- a/java/src/main/java/io/worlds/api/model/ActivityChronicleSummaryBucketType.java
+++ b/java/src/main/java/io/worlds/api/model/ActivityChronicleSummaryBucketType.java
@@ -12,6 +12,7 @@ public class ActivityChronicleSummaryBucketType implements java.io.Serializable 
     private static final long serialVersionUID = 1L;
 
     private org.springframework.graphql.data.ArgumentValue<SummaryBucketSize> size = org.springframework.graphql.data.ArgumentValue.omitted();
+    @Deprecated
     private org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy = org.springframework.graphql.data.ArgumentValue.omitted();
     private java.util.List<ActivityChronicleSummaryBucketField> fields;
     private java.util.List<JSONFieldStringBucket> metadata;
@@ -33,9 +34,11 @@ public class ActivityChronicleSummaryBucketType implements java.io.Serializable 
         this.size = size;
     }
 
+    @Deprecated
     public org.springframework.graphql.data.ArgumentValue<BucketingStrategy> getBucketingStrategy() {
         return bucketingStrategy;
     }
+    @Deprecated
     public void setBucketingStrategy(org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy) {
         this.bucketingStrategy = bucketingStrategy;
     }
@@ -94,6 +97,7 @@ public class ActivityChronicleSummaryBucketType implements java.io.Serializable 
             return this;
         }
 
+        @Deprecated
         public Builder setBucketingStrategy(org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy) {
             this.bucketingStrategy = bucketingStrategy;
             return this;

--- a/java/src/main/java/io/worlds/api/model/EventsSummaryBucketType.java
+++ b/java/src/main/java/io/worlds/api/model/EventsSummaryBucketType.java
@@ -12,6 +12,7 @@ public class EventsSummaryBucketType implements java.io.Serializable {
     private static final long serialVersionUID = 1L;
 
     private org.springframework.graphql.data.ArgumentValue<SummaryBucketSize> size = org.springframework.graphql.data.ArgumentValue.omitted();
+    @Deprecated
     private org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy = org.springframework.graphql.data.ArgumentValue.omitted();
     private java.util.List<EventsSummaryBucketField> fields;
     private java.util.List<JSONFieldStringBucket> metadata;
@@ -33,9 +34,11 @@ public class EventsSummaryBucketType implements java.io.Serializable {
         this.size = size;
     }
 
+    @Deprecated
     public org.springframework.graphql.data.ArgumentValue<BucketingStrategy> getBucketingStrategy() {
         return bucketingStrategy;
     }
+    @Deprecated
     public void setBucketingStrategy(org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy) {
         this.bucketingStrategy = bucketingStrategy;
     }
@@ -94,6 +97,7 @@ public class EventsSummaryBucketType implements java.io.Serializable {
             return this;
         }
 
+        @Deprecated
         public Builder setBucketingStrategy(org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy) {
             this.bucketingStrategy = bucketingStrategy;
             return this;

--- a/java/src/main/java/io/worlds/api/model/Site.java
+++ b/java/src/main/java/io/worlds/api/model/Site.java
@@ -65,13 +65,13 @@ public class Site implements java.io.Serializable, UnifiedSearchNameResponseEnti
     }
 
     /**
-     * The IANA timezone identifier for this site (e.g. 'America/New_York', 'Europe/London', 'UTC').
+     * The IANA timezone identifier for this site (e.g. 'America/New_York', 'UTC').
      */
     public String getTimezone() {
         return timezone;
     }
     /**
-     * The IANA timezone identifier for this site (e.g. 'America/New_York', 'Europe/London', 'UTC').
+     * The IANA timezone identifier for this site (e.g. 'America/New_York', 'UTC').
      */
     public void setTimezone(String timezone) {
         this.timezone = timezone;
@@ -202,7 +202,7 @@ public class Site implements java.io.Serializable, UnifiedSearchNameResponseEnti
         }
 
         /**
-         * The IANA timezone identifier for this site (e.g. 'America/New_York', 'Europe/London', 'UTC').
+         * The IANA timezone identifier for this site (e.g. 'America/New_York', 'UTC').
          */
         public Builder setTimezone(String timezone) {
             this.timezone = timezone;

--- a/java/src/main/java/io/worlds/api/model/TracksSummaryBucketType.java
+++ b/java/src/main/java/io/worlds/api/model/TracksSummaryBucketType.java
@@ -12,6 +12,7 @@ public class TracksSummaryBucketType implements java.io.Serializable {
     private static final long serialVersionUID = 1L;
 
     private org.springframework.graphql.data.ArgumentValue<SummaryBucketSize> size = org.springframework.graphql.data.ArgumentValue.omitted();
+    @Deprecated
     private org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy = org.springframework.graphql.data.ArgumentValue.omitted();
     private java.util.List<TracksSummaryBucketField> fields;
 
@@ -31,9 +32,11 @@ public class TracksSummaryBucketType implements java.io.Serializable {
         this.size = size;
     }
 
+    @Deprecated
     public org.springframework.graphql.data.ArgumentValue<BucketingStrategy> getBucketingStrategy() {
         return bucketingStrategy;
     }
+    @Deprecated
     public void setBucketingStrategy(org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy) {
         this.bucketingStrategy = bucketingStrategy;
     }
@@ -83,6 +86,7 @@ public class TracksSummaryBucketType implements java.io.Serializable {
             return this;
         }
 
+        @Deprecated
         public Builder setBucketingStrategy(org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy) {
             this.bucketingStrategy = bucketingStrategy;
             return this;

--- a/java/src/main/java/io/worlds/api/model/ZoneIntersectionSummaryBucketType.java
+++ b/java/src/main/java/io/worlds/api/model/ZoneIntersectionSummaryBucketType.java
@@ -12,6 +12,7 @@ public class ZoneIntersectionSummaryBucketType implements java.io.Serializable {
     private static final long serialVersionUID = 1L;
 
     private org.springframework.graphql.data.ArgumentValue<SummaryBucketSize> size = org.springframework.graphql.data.ArgumentValue.omitted();
+    @Deprecated
     private org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy = org.springframework.graphql.data.ArgumentValue.omitted();
     private java.util.List<ZoneIntersectionSummaryBucketField> fields;
 
@@ -31,9 +32,11 @@ public class ZoneIntersectionSummaryBucketType implements java.io.Serializable {
         this.size = size;
     }
 
+    @Deprecated
     public org.springframework.graphql.data.ArgumentValue<BucketingStrategy> getBucketingStrategy() {
         return bucketingStrategy;
     }
+    @Deprecated
     public void setBucketingStrategy(org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy) {
         this.bucketingStrategy = bucketingStrategy;
     }
@@ -83,6 +86,7 @@ public class ZoneIntersectionSummaryBucketType implements java.io.Serializable {
             return this;
         }
 
+        @Deprecated
         public Builder setBucketingStrategy(org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy) {
             this.bucketingStrategy = bucketingStrategy;
             return this;


### PR DESCRIPTION
## Description of Changes
Move `bucketingStrategy` from bucket input types to query parameters.  Deprecate the `bucketingStrategy` on the bucket input types.

This allows top-level and bucketed results to use the same filters and STARTED/ENDED strategy optimizations.

## Link to Related Jira Ticket
[CE-5398]

[CE-5398]: https://worlds-io.atlassian.net/browse/CE-5398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ