### PR TITLE
feat(java): upgrade to Spring 7, Jackson 3, and modern deps

### DIFF
--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -24,57 +24,62 @@
         <dependency>
             <groupId>org.springframework.graphql</groupId>
             <artifactId>spring-graphql</artifactId>
-            <version>1.4.1</version>
+            <version>2.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webflux</artifactId>
-            <version>6.1.14</version>
+            <version>7.0.6</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty-http</artifactId>
-            <version>1.2.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>6.1.21</version>
+            <version>1.3.4</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.16</version>
+            <version>2.0.17</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.18.6</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.15.4</version>
-            <scope>test</scope>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.10.2</version>
+            <version>6.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.38</version>
+            <version>1.18.44</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.44</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <distributionManagement>
         <repository>

--- a/java-client/src/main/java/io/worlds/api/client/WorldsGraphQLClient.java
+++ b/java-client/src/main/java/io/worlds/api/client/WorldsGraphQLClient.java
@@ -8,9 +8,9 @@
  */
 package io.worlds.api.client;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import java.net.URI;
@@ -157,7 +157,7 @@ public class WorldsGraphQLClient {
                                    onError.accept(new RuntimeException("Received null data in subscription response"));
                                    return;
                                }
-                               var contentField = dataNode.fieldNames().next();
+                               var contentField = dataNode.propertyNames().iterator().next();
                                if (contentField == null) {
                                    onError.accept(new RuntimeException("No content field found in subscription data"));
                                    return;
@@ -169,7 +169,7 @@ public class WorldsGraphQLClient {
                                }
                                T value = objectMapper.treeToValue(contentNode, type);
                                onMessage.accept(value);
-                           } catch (JsonProcessingException jpe) {
+                           } catch (JacksonException jpe) {
                                onError.accept(jpe);
                            }
                        }).subscribe();

--- a/java-client/src/test/java/io/worlds/api/client/GraphQLClientTest.java
+++ b/java-client/src/test/java/io/worlds/api/client/GraphQLClientTest.java
@@ -1,8 +1,8 @@
 package io.worlds.api.client;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import io.worlds.api.model.Event;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,13 +26,13 @@ public class GraphQLClientTest {
     private WorldsGraphQLClient client;
     private String tokenId;
     private String tokenValue;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = JsonMapper.builder()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+            .build();
 
     @BeforeAll
     void setup() {
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
 
         String url = System.getenv().getOrDefault("GRAPHQL_URL", "https://api.dev.eus.azure.worlds.io/graphql");
         tokenId = System.getenv().getOrDefault("GRAPHQL_TOKEN_ID", "replace_me");

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.springframework.graphql</groupId>
       <artifactId>spring-graphql</artifactId>
-      <version>1.3.4</version>
+      <version>2.0.2</version>
     </dependency>
     <dependency>
       <groupId>jakarta.validation</groupId>


### PR DESCRIPTION
## Summary

Upgrades `java` and `java-client` dependencies to align with the Spring Boot 4.0.5 / Spring Framework 7 ecosystem.

**java-client:**
- Spring GraphQL 2.0.2, WebFlux 7.0.6, Reactor Netty 1.3.4
- Jackson 2.x (`com.fasterxml`) → Jackson 3.1.0 (`tools.jackson`), with JSR-310 support now built into databind
- JUnit 6.0.3, SLF4J 2.0.17, Lombok 1.18.44
- Added `maven-compiler-plugin` 3.14.1 with Lombok annotation processor config
- Jackson 3 source migration: `ObjectMapper`/`JsonNode`/`JacksonException` imports, `fieldNames()` → `propertyNames()`, immutable `JsonMapper.builder()` pattern

**java (SDK):**
- Spring GraphQL 1.3.4 → 2.0.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)