### PR TITLE
CE-4863: Add position bucketing to activity summary

### DIFF
--- a/graphql/api/domains/summary/filter.graphqls
+++ b/graphql/api/domains/summary/filter.graphqls
@@ -120,6 +120,10 @@ input FilterActivityChronicleSummaryInput {
     """
     approvalStatus: FilterStringInput
     """
+    If provided, specifies filters that work against the position of the activity.
+    """
+    position: FilterPointInput
+    """
     If provided, specifies filters that work against the user-defined activity metadata.
     """
     metadata: FilterJSONFieldStringInput

--- a/graphql/api/domains/summary/summary.graphqls
+++ b/graphql/api/domains/summary/summary.graphqls
@@ -231,6 +231,8 @@ type ActivityChronicleSummaryBucketKey {
     validationStatus: String
     """The `approvalStatus` of the activity chronicles in the summary bucket."""
     approvalStatus: String
+    """The approximate centroid of the H3 cell for position-bucketed results."""
+    position: GeoJSONPoint
     """The metadata values of the activity chronicles in the summary bucket."""
     metadata: [JSONFieldBucketKey!]
 }

--- a/graphql/api/domains/summary/summary.graphqls
+++ b/graphql/api/domains/summary/summary.graphqls
@@ -231,8 +231,8 @@ type ActivityChronicleSummaryBucketKey {
     validationStatus: String
     """The `approvalStatus` of the activity chronicles in the summary bucket."""
     approvalStatus: String
-    """The approximate centroid of the H3 cell for position-bucketed results."""
-    position: GeoJSONPoint
+    """The H3 cell for position-bucketed results."""
+    position: H3Cell
     """The metadata values of the activity chronicles in the summary bucket."""
     metadata: [JSONFieldBucketKey!]
 }

--- a/graphql/api/domains/summary/util.graphqls
+++ b/graphql/api/domains/summary/util.graphqls
@@ -139,40 +139,42 @@ enum ActivityChronicleSummaryBucketField {
     APPROVAL_STATUS
 }
 
-### TODO: Some of these can probably be omitted.  Possibly move to more descriptive names.
-"""Indicates the H3 resolution level for position bucketing. Higher resolutions produce smaller, more precise cells."""
+"""
+Indicates the H3 resolution level for position bucketing. Higher resolutions produce smaller cells.
+Refer to [the H3 docs](https://h3geo.org/docs/core-library/restable) for more detailed statistics on resolution.
+"""
 enum PositionBucketPrecision {
-    """H3 resolution 0 (~4,357 km² average cell area)"""
+    """H3 resolution 0 (~4.3 million km² average cell area)"""
     RESOLUTION_0
-    """H3 resolution 1 (~609 km²)"""
+    """H3 resolution 1 (~600,000 km²)"""
     RESOLUTION_1
-    """H3 resolution 2 (~87 km²)"""
+    """H3 resolution 2 (~87,000 km²)"""
     RESOLUTION_2
-    """H3 resolution 3 (~12 km²)"""
+    """H3 resolution 3 (~12,000 km²)"""
     RESOLUTION_3
-    """H3 resolution 4 (~1.77 km²)"""
+    """H3 resolution 4 (~1,770 km²)"""
     RESOLUTION_4
-    """H3 resolution 5 (~0.253 km²)"""
+    """H3 resolution 5 (~253 km²)"""
     RESOLUTION_5
-    """H3 resolution 6 (~0.036 km²)"""
+    """H3 resolution 6 (~36 km²)"""
     RESOLUTION_6
-    """H3 resolution 7 (~0.005 km²)"""
+    """H3 resolution 7 (~5 km²)"""
     RESOLUTION_7
-    """H3 resolution 8 (~0.00074 km²)"""
+    """H3 resolution 8 (~0.7 km²)"""
     RESOLUTION_8
-    """H3 resolution 9 (~0.000105 km²)"""
+    """H3 resolution 9 (~0.1 km² or ~100,000 m²)"""
     RESOLUTION_9
-    """H3 resolution 10"""
+    """H3 resolution 10 (~15,000 m²)"""
     RESOLUTION_10
-    """H3 resolution 11"""
+    """H3 resolution 11 (~2,000 m²)"""
     RESOLUTION_11
-    """H3 resolution 12"""
+    """H3 resolution 12 (~300 m²)"""
     RESOLUTION_12
-    """H3 resolution 13"""
+    """H3 resolution 13 (~40 m²)"""
     RESOLUTION_13
-    """H3 resolution 14"""
+    """H3 resolution 14 (~6 m²)"""
     RESOLUTION_14
-    """H3 resolution 15 (finest resolution)"""
+    """H3 resolution 15 (~0.9 m²)"""
     RESOLUTION_15
 }
 

--- a/graphql/api/domains/summary/util.graphqls
+++ b/graphql/api/domains/summary/util.graphqls
@@ -139,6 +139,43 @@ enum ActivityChronicleSummaryBucketField {
     APPROVAL_STATUS
 }
 
+### TODO: Some of these can probably be omitted.  Possibly move to more descriptive names.
+"""Indicates the H3 resolution level for position bucketing. Higher resolutions produce smaller, more precise cells."""
+enum PositionBucketPrecision {
+    """H3 resolution 0 (~4,357 km² average cell area)"""
+    RESOLUTION_0
+    """H3 resolution 1 (~609 km²)"""
+    RESOLUTION_1
+    """H3 resolution 2 (~87 km²)"""
+    RESOLUTION_2
+    """H3 resolution 3 (~12 km²)"""
+    RESOLUTION_3
+    """H3 resolution 4 (~1.77 km²)"""
+    RESOLUTION_4
+    """H3 resolution 5 (~0.253 km²)"""
+    RESOLUTION_5
+    """H3 resolution 6 (~0.036 km²)"""
+    RESOLUTION_6
+    """H3 resolution 7 (~0.005 km²)"""
+    RESOLUTION_7
+    """H3 resolution 8 (~0.00074 km²)"""
+    RESOLUTION_8
+    """H3 resolution 9 (~0.000105 km²)"""
+    RESOLUTION_9
+    """H3 resolution 10"""
+    RESOLUTION_10
+    """H3 resolution 11"""
+    RESOLUTION_11
+    """H3 resolution 12"""
+    RESOLUTION_12
+    """H3 resolution 13"""
+    RESOLUTION_13
+    """H3 resolution 14"""
+    RESOLUTION_14
+    """H3 resolution 15 (finest resolution)"""
+    RESOLUTION_15
+}
+
 """
 Input to indicate which field(s) to group activity chronicles by in an `activityChronicleSummary` query.
 Any combination of up to three distinct fields may be provided.
@@ -151,6 +188,8 @@ input ActivityChronicleSummaryBucketType {
     bucketingStrategy: BucketingStrategy @deprecated(reason: "bucketingStrategy is deprecated on ActivityChronicleSummaryBucketType.  Instead, use the query parameter for bucketingStrategy to specify for both top-level and bucketed results.  If this field is provided, it will overwrite the query parameter.")
     """If provided, group the summary buckets by the values of the provided fields."""
     fields: [ActivityChronicleSummaryBucketField!]
+    """If provided, group the summary buckets by position at the specified H3 resolution. Activities without a position will be grouped under a null key."""
+    position: PositionBucketPrecision
     """If provided, group the summary buckets by the values of the provided metadata fields."""
     metadata: [JSONFieldStringBucket!]
 }

--- a/graphql/api/domains/summary/util.graphqls
+++ b/graphql/api/domains/summary/util.graphqls
@@ -178,10 +178,10 @@ enum PositionBucketPrecision {
     RESOLUTION_10
     """H3 resolution 11 (~2,000 m²)"""
     RESOLUTION_11
-    """Small-scale resolution, ~2,000 m² per cell. Alias for `RESOLUTION_11`"""
-    BUILDING
     """H3 resolution 12 (~300 m²)"""
     RESOLUTION_12
+    """Small-scale resolution, ~300 m² per cell. Alias for `RESOLUTION_12`"""
+    BUILDING
     """H3 resolution 13 (~40 m²)"""
     RESOLUTION_13
     """H3 resolution 14 (~6 m²)"""

--- a/graphql/api/domains/summary/util.graphqls
+++ b/graphql/api/domains/summary/util.graphqls
@@ -148,7 +148,7 @@ Refer to [the H3 docs](https://h3geo.org/docs/core-library/restable) for more de
 enum PositionBucketPrecision {
     """H3 resolution 0 (~4.3 million km² average cell area)"""
     RESOLUTION_0
-    """Extra-large-scale resolution,  ~4.3 million km² per cell. Alias for `RESOLUTION_0`"""
+    """Extra-large-scale resolution, ~4.3 million km² per cell. Alias for `RESOLUTION_0`"""
     CONTINENTAL
     """H3 resolution 1 (~600,000 km²)"""
     RESOLUTION_1

--- a/graphql/api/domains/summary/util.graphqls
+++ b/graphql/api/domains/summary/util.graphqls
@@ -140,12 +140,16 @@ enum ActivityChronicleSummaryBucketField {
 }
 
 """
-Indicates the H3 resolution level for position bucketing. Higher resolutions produce smaller cells.
+Indicates the resolution level for position bucketing. Higher resolutions produce smaller cells.
+Options will either be a H3 resolution (`RESOLUTION_0` through `RESOLUTION_15`), or a semantic name referring to one of the H3 resolutions.
+On average, the area of a cell divides by 7 at each new resolution.
 Refer to [the H3 docs](https://h3geo.org/docs/core-library/restable) for more detailed statistics on resolution.
 """
 enum PositionBucketPrecision {
     """H3 resolution 0 (~4.3 million km² average cell area)"""
     RESOLUTION_0
+    """Extra-large-scale resolution,  ~4.3 million km² per cell. Alias for `RESOLUTION_0`"""
+    CONTINENTAL
     """H3 resolution 1 (~600,000 km²)"""
     RESOLUTION_1
     """H3 resolution 2 (~87,000 km²)"""
@@ -154,20 +158,28 @@ enum PositionBucketPrecision {
     RESOLUTION_3
     """H3 resolution 4 (~1,770 km²)"""
     RESOLUTION_4
+    """Large-scale resolution, ~1,700 km² per cell. Alias for `RESOLUTION_5`"""
+    REGIONAL
     """H3 resolution 5 (~253 km²)"""
     RESOLUTION_5
     """H3 resolution 6 (~36 km²)"""
     RESOLUTION_6
     """H3 resolution 7 (~5 km²)"""
     RESOLUTION_7
+    """Medium-scale resolution, ~5 km² per cell. Alias for `RESOLUTION_7`"""
+    DISTRICT
     """H3 resolution 8 (~0.7 km²)"""
     RESOLUTION_8
     """H3 resolution 9 (~0.1 km² or ~100,000 m²)"""
     RESOLUTION_9
+    """Small-scale resolution, ~100,000 m² per cell. Alias for `RESOLUTION_9`"""
+    NEIGHBORHOOD
     """H3 resolution 10 (~15,000 m²)"""
     RESOLUTION_10
     """H3 resolution 11 (~2,000 m²)"""
     RESOLUTION_11
+    """Small-scale resolution, ~2,000 m² per cell. Alias for `RESOLUTION_11`"""
+    BUILDING
     """H3 resolution 12 (~300 m²)"""
     RESOLUTION_12
     """H3 resolution 13 (~40 m²)"""

--- a/graphql/api/geojson.graphqls
+++ b/graphql/api/geojson.graphqls
@@ -107,6 +107,20 @@ type GeoJSONCRS {
 }
 
 """
+A `H3Cell` represents a geographical area, useful for grouping nearby points.  Refer to [the H3 documentation](https://h3geo.org/docs) for more information on the structure.
+"""
+type H3Cell {
+    """
+    The canonical string index of the cell.  See [the H3 docs](https://h3geo.org/docs/library/index/cell).
+    """
+    index: String!
+    """
+    The coordinates of the approximate centroid of the cell.
+    """
+    center: GeoJSONPoint
+}
+
+"""
 This type represents the input data needed to initialize a [GeoJSON point]({{Types.GeoJSONPoint}}).
 """
 input GeoJSONPointInput {

--- a/graphql/api/geojson.graphqls
+++ b/graphql/api/geojson.graphqls
@@ -111,7 +111,7 @@ A `H3Cell` represents a geographical area, useful for grouping nearby points.  R
 """
 type H3Cell {
     """
-    The canonical string index of the cell.  See [the H3 docs](https://h3geo.org/docs/library/index/cell).
+    The canonical string index of the cell.  Can be used with H3 libraries for additional information on the cell's shape, size, and position.  See [the H3 docs](https://h3geo.org/docs/library/index/cell) for more information.
     """
     index: String!
     """

--- a/java/src/main/java/io/worlds/api/model/ActivityChronicleSummaryBucketKey.java
+++ b/java/src/main/java/io/worlds/api/model/ActivityChronicleSummaryBucketKey.java
@@ -20,12 +20,13 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
     private String label;
     private String validationStatus;
     private String approvalStatus;
+    private GeoJSONPoint position;
     private java.util.List<JSONFieldBucketKey> metadata;
 
     public ActivityChronicleSummaryBucketKey() {
     }
 
-    public ActivityChronicleSummaryBucketKey(java.time.OffsetDateTime time, String name, String description, String priority, String status, ChronicleProducer chronicleProducer, Site site, DataSource dataSource, String label, String validationStatus, String approvalStatus, java.util.List<JSONFieldBucketKey> metadata) {
+    public ActivityChronicleSummaryBucketKey(java.time.OffsetDateTime time, String name, String description, String priority, String status, ChronicleProducer chronicleProducer, Site site, DataSource dataSource, String label, String validationStatus, String approvalStatus, GeoJSONPoint position, java.util.List<JSONFieldBucketKey> metadata) {
         this.time = time;
         this.name = name;
         this.description = description;
@@ -37,6 +38,7 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
         this.label = label;
         this.validationStatus = validationStatus;
         this.approvalStatus = approvalStatus;
+        this.position = position;
         this.metadata = metadata;
     }
 
@@ -184,6 +186,19 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
     }
 
     /**
+     * The approximate centroid of the H3 cell for position-bucketed results.
+     */
+    public GeoJSONPoint getPosition() {
+        return position;
+    }
+    /**
+     * The approximate centroid of the H3 cell for position-bucketed results.
+     */
+    public void setPosition(GeoJSONPoint position) {
+        this.position = position;
+    }
+
+    /**
      * The metadata values of the activity chronicles in the summary bucket.
      */
     public java.util.List<JSONFieldBucketKey> getMetadata() {
@@ -216,12 +231,13 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
             && Objects.equals(label, that.label)
             && Objects.equals(validationStatus, that.validationStatus)
             && Objects.equals(approvalStatus, that.approvalStatus)
+            && Objects.equals(position, that.position)
             && Objects.equals(metadata, that.metadata);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(time, name, description, priority, status, chronicleProducer, site, dataSource, label, validationStatus, approvalStatus, metadata);
+        return Objects.hash(time, name, description, priority, status, chronicleProducer, site, dataSource, label, validationStatus, approvalStatus, position, metadata);
     }
 
 
@@ -242,6 +258,7 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
         private String label;
         private String validationStatus;
         private String approvalStatus;
+        private GeoJSONPoint position;
         private java.util.List<JSONFieldBucketKey> metadata;
 
         public Builder() {
@@ -336,6 +353,14 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
         }
 
         /**
+         * The approximate centroid of the H3 cell for position-bucketed results.
+         */
+        public Builder setPosition(GeoJSONPoint position) {
+            this.position = position;
+            return this;
+        }
+
+        /**
          * The metadata values of the activity chronicles in the summary bucket.
          */
         public Builder setMetadata(java.util.List<JSONFieldBucketKey> metadata) {
@@ -345,7 +370,7 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
 
 
         public ActivityChronicleSummaryBucketKey build() {
-            return new ActivityChronicleSummaryBucketKey(time, name, description, priority, status, chronicleProducer, site, dataSource, label, validationStatus, approvalStatus, metadata);
+            return new ActivityChronicleSummaryBucketKey(time, name, description, priority, status, chronicleProducer, site, dataSource, label, validationStatus, approvalStatus, position, metadata);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/ActivityChronicleSummaryBucketKey.java
+++ b/java/src/main/java/io/worlds/api/model/ActivityChronicleSummaryBucketKey.java
@@ -20,13 +20,13 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
     private String label;
     private String validationStatus;
     private String approvalStatus;
-    private GeoJSONPoint position;
+    private H3Cell position;
     private java.util.List<JSONFieldBucketKey> metadata;
 
     public ActivityChronicleSummaryBucketKey() {
     }
 
-    public ActivityChronicleSummaryBucketKey(java.time.OffsetDateTime time, String name, String description, String priority, String status, ChronicleProducer chronicleProducer, Site site, DataSource dataSource, String label, String validationStatus, String approvalStatus, GeoJSONPoint position, java.util.List<JSONFieldBucketKey> metadata) {
+    public ActivityChronicleSummaryBucketKey(java.time.OffsetDateTime time, String name, String description, String priority, String status, ChronicleProducer chronicleProducer, Site site, DataSource dataSource, String label, String validationStatus, String approvalStatus, H3Cell position, java.util.List<JSONFieldBucketKey> metadata) {
         this.time = time;
         this.name = name;
         this.description = description;
@@ -186,15 +186,15 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
     }
 
     /**
-     * The approximate centroid of the H3 cell for position-bucketed results.
+     * The H3 cell for position-bucketed results.
      */
-    public GeoJSONPoint getPosition() {
+    public H3Cell getPosition() {
         return position;
     }
     /**
-     * The approximate centroid of the H3 cell for position-bucketed results.
+     * The H3 cell for position-bucketed results.
      */
-    public void setPosition(GeoJSONPoint position) {
+    public void setPosition(H3Cell position) {
         this.position = position;
     }
 
@@ -258,7 +258,7 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
         private String label;
         private String validationStatus;
         private String approvalStatus;
-        private GeoJSONPoint position;
+        private H3Cell position;
         private java.util.List<JSONFieldBucketKey> metadata;
 
         public Builder() {
@@ -353,9 +353,9 @@ public class ActivityChronicleSummaryBucketKey implements java.io.Serializable {
         }
 
         /**
-         * The approximate centroid of the H3 cell for position-bucketed results.
+         * The H3 cell for position-bucketed results.
          */
-        public Builder setPosition(GeoJSONPoint position) {
+        public Builder setPosition(H3Cell position) {
             this.position = position;
             return this;
         }

--- a/java/src/main/java/io/worlds/api/model/ActivityChronicleSummaryBucketType.java
+++ b/java/src/main/java/io/worlds/api/model/ActivityChronicleSummaryBucketType.java
@@ -15,15 +15,17 @@ public class ActivityChronicleSummaryBucketType implements java.io.Serializable 
     @Deprecated
     private org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy = org.springframework.graphql.data.ArgumentValue.omitted();
     private java.util.List<ActivityChronicleSummaryBucketField> fields;
+    private org.springframework.graphql.data.ArgumentValue<PositionBucketPrecision> position = org.springframework.graphql.data.ArgumentValue.omitted();
     private java.util.List<JSONFieldStringBucket> metadata;
 
     public ActivityChronicleSummaryBucketType() {
     }
 
-    public ActivityChronicleSummaryBucketType(org.springframework.graphql.data.ArgumentValue<SummaryBucketSize> size, org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy, java.util.List<ActivityChronicleSummaryBucketField> fields, java.util.List<JSONFieldStringBucket> metadata) {
+    public ActivityChronicleSummaryBucketType(org.springframework.graphql.data.ArgumentValue<SummaryBucketSize> size, org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy, java.util.List<ActivityChronicleSummaryBucketField> fields, org.springframework.graphql.data.ArgumentValue<PositionBucketPrecision> position, java.util.List<JSONFieldStringBucket> metadata) {
         this.size = size;
         this.bucketingStrategy = bucketingStrategy;
         this.fields = fields;
+        this.position = position;
         this.metadata = metadata;
     }
 
@@ -50,6 +52,13 @@ public class ActivityChronicleSummaryBucketType implements java.io.Serializable 
         this.fields = fields;
     }
 
+    public org.springframework.graphql.data.ArgumentValue<PositionBucketPrecision> getPosition() {
+        return position;
+    }
+    public void setPosition(org.springframework.graphql.data.ArgumentValue<PositionBucketPrecision> position) {
+        this.position = position;
+    }
+
     public java.util.List<JSONFieldStringBucket> getMetadata() {
         return metadata;
     }
@@ -69,12 +78,13 @@ public class ActivityChronicleSummaryBucketType implements java.io.Serializable 
         return Objects.equals(size, that.size)
             && Objects.equals(bucketingStrategy, that.bucketingStrategy)
             && Objects.equals(fields, that.fields)
+            && Objects.equals(position, that.position)
             && Objects.equals(metadata, that.metadata);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(size, bucketingStrategy, fields, metadata);
+        return Objects.hash(size, bucketingStrategy, fields, position, metadata);
     }
 
 
@@ -87,6 +97,7 @@ public class ActivityChronicleSummaryBucketType implements java.io.Serializable 
         private org.springframework.graphql.data.ArgumentValue<SummaryBucketSize> size = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<BucketingStrategy> bucketingStrategy = org.springframework.graphql.data.ArgumentValue.omitted();
         private java.util.List<ActivityChronicleSummaryBucketField> fields;
+        private org.springframework.graphql.data.ArgumentValue<PositionBucketPrecision> position = org.springframework.graphql.data.ArgumentValue.omitted();
         private java.util.List<JSONFieldStringBucket> metadata;
 
         public Builder() {
@@ -108,6 +119,11 @@ public class ActivityChronicleSummaryBucketType implements java.io.Serializable 
             return this;
         }
 
+        public Builder setPosition(org.springframework.graphql.data.ArgumentValue<PositionBucketPrecision> position) {
+            this.position = position;
+            return this;
+        }
+
         public Builder setMetadata(java.util.List<JSONFieldStringBucket> metadata) {
             this.metadata = metadata;
             return this;
@@ -115,7 +131,7 @@ public class ActivityChronicleSummaryBucketType implements java.io.Serializable 
 
 
         public ActivityChronicleSummaryBucketType build() {
-            return new ActivityChronicleSummaryBucketType(size, bucketingStrategy, fields, metadata);
+            return new ActivityChronicleSummaryBucketType(size, bucketingStrategy, fields, position, metadata);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/BucketingStrategy.java
+++ b/java/src/main/java/io/worlds/api/model/BucketingStrategy.java
@@ -1,0 +1,32 @@
+package io.worlds.api.model;
+
+/**
+ * Indicates how to bucket objects.  In buckets, `total` count will differ by the bucketing strategy.
+ */
+public enum BucketingStrategy {
+
+    /**
+     * Bucket into all buckets where the object was active.  With this strategy, an object may be present in multiple time buckets.
+     */
+    ACTIVE("ACTIVE"),
+    /**
+     * Bucket into the bucket where the object ended. `total` will be equal to `startedCount`. `endedCount` will return as 0.
+     */
+    STARTED("STARTED"),
+    /**
+     * Bucket into the bucket where the object ended. `total` will be equal to `endedCount`. `startedCount` will return as 0.
+     */
+    ENDED("ENDED");
+
+    private final String graphqlName;
+
+    private BucketingStrategy(String graphqlName) {
+        this.graphqlName = graphqlName;
+    }
+
+    @Override
+    public String toString() {
+        return this.graphqlName;
+    }
+
+}

--- a/java/src/main/java/io/worlds/api/model/FilterActivityChronicleSummaryInput.java
+++ b/java/src/main/java/io/worlds/api/model/FilterActivityChronicleSummaryInput.java
@@ -21,6 +21,7 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> status = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterChronicleValidationStatusInput> validationStatus = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> approvalStatus = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<FilterPointInput> position = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterJSONFieldStringInput> metadata = org.springframework.graphql.data.ArgumentValue.omitted();
     private java.util.List<FilterActivityChronicleSummaryInput> and;
     private java.util.List<FilterActivityChronicleSummaryInput> or;
@@ -29,7 +30,7 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
     public FilterActivityChronicleSummaryInput() {
     }
 
-    public FilterActivityChronicleSummaryInput(org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> startTime, org.springframework.graphql.data.ArgumentValue<FilterStringInput> name, org.springframework.graphql.data.ArgumentValue<FilterStringInput> description, org.springframework.graphql.data.ArgumentValue<FilterIDInput> chronicleProducerId, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> dataSourceIds, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> siteIds, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> labels, org.springframework.graphql.data.ArgumentValue<FilterStringInput> priority, org.springframework.graphql.data.ArgumentValue<FilterStringInput> status, org.springframework.graphql.data.ArgumentValue<FilterChronicleValidationStatusInput> validationStatus, org.springframework.graphql.data.ArgumentValue<FilterStringInput> approvalStatus, org.springframework.graphql.data.ArgumentValue<FilterJSONFieldStringInput> metadata, java.util.List<FilterActivityChronicleSummaryInput> and, java.util.List<FilterActivityChronicleSummaryInput> or, org.springframework.graphql.data.ArgumentValue<FilterActivityChronicleSummaryInput> not) {
+    public FilterActivityChronicleSummaryInput(org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> startTime, org.springframework.graphql.data.ArgumentValue<FilterStringInput> name, org.springframework.graphql.data.ArgumentValue<FilterStringInput> description, org.springframework.graphql.data.ArgumentValue<FilterIDInput> chronicleProducerId, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> dataSourceIds, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> siteIds, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> labels, org.springframework.graphql.data.ArgumentValue<FilterStringInput> priority, org.springframework.graphql.data.ArgumentValue<FilterStringInput> status, org.springframework.graphql.data.ArgumentValue<FilterChronicleValidationStatusInput> validationStatus, org.springframework.graphql.data.ArgumentValue<FilterStringInput> approvalStatus, org.springframework.graphql.data.ArgumentValue<FilterPointInput> position, org.springframework.graphql.data.ArgumentValue<FilterJSONFieldStringInput> metadata, java.util.List<FilterActivityChronicleSummaryInput> and, java.util.List<FilterActivityChronicleSummaryInput> or, org.springframework.graphql.data.ArgumentValue<FilterActivityChronicleSummaryInput> not) {
         this.startTime = startTime;
         this.name = name;
         this.description = description;
@@ -41,6 +42,7 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
         this.status = status;
         this.validationStatus = validationStatus;
         this.approvalStatus = approvalStatus;
+        this.position = position;
         this.metadata = metadata;
         this.and = and;
         this.or = or;
@@ -124,6 +126,13 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
         this.approvalStatus = approvalStatus;
     }
 
+    public org.springframework.graphql.data.ArgumentValue<FilterPointInput> getPosition() {
+        return position;
+    }
+    public void setPosition(org.springframework.graphql.data.ArgumentValue<FilterPointInput> position) {
+        this.position = position;
+    }
+
     public org.springframework.graphql.data.ArgumentValue<FilterJSONFieldStringInput> getMetadata() {
         return metadata;
     }
@@ -172,6 +181,7 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
             && Objects.equals(status, that.status)
             && Objects.equals(validationStatus, that.validationStatus)
             && Objects.equals(approvalStatus, that.approvalStatus)
+            && Objects.equals(position, that.position)
             && Objects.equals(metadata, that.metadata)
             && Objects.equals(and, that.and)
             && Objects.equals(or, that.or)
@@ -180,7 +190,7 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
 
     @Override
     public int hashCode() {
-        return Objects.hash(startTime, name, description, chronicleProducerId, dataSourceIds, siteIds, labels, priority, status, validationStatus, approvalStatus, metadata, and, or, not);
+        return Objects.hash(startTime, name, description, chronicleProducerId, dataSourceIds, siteIds, labels, priority, status, validationStatus, approvalStatus, position, metadata, and, or, not);
     }
 
 
@@ -201,6 +211,7 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> status = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterChronicleValidationStatusInput> validationStatus = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> approvalStatus = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<FilterPointInput> position = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterJSONFieldStringInput> metadata = org.springframework.graphql.data.ArgumentValue.omitted();
         private java.util.List<FilterActivityChronicleSummaryInput> and;
         private java.util.List<FilterActivityChronicleSummaryInput> or;
@@ -264,6 +275,11 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
             return this;
         }
 
+        public Builder setPosition(org.springframework.graphql.data.ArgumentValue<FilterPointInput> position) {
+            this.position = position;
+            return this;
+        }
+
         public Builder setMetadata(org.springframework.graphql.data.ArgumentValue<FilterJSONFieldStringInput> metadata) {
             this.metadata = metadata;
             return this;
@@ -286,7 +302,7 @@ public class FilterActivityChronicleSummaryInput implements java.io.Serializable
 
 
         public FilterActivityChronicleSummaryInput build() {
-            return new FilterActivityChronicleSummaryInput(startTime, name, description, chronicleProducerId, dataSourceIds, siteIds, labels, priority, status, validationStatus, approvalStatus, metadata, and, or, not);
+            return new FilterActivityChronicleSummaryInput(startTime, name, description, chronicleProducerId, dataSourceIds, siteIds, labels, priority, status, validationStatus, approvalStatus, position, metadata, and, or, not);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/H3Cell.java
+++ b/java/src/main/java/io/worlds/api/model/H3Cell.java
@@ -1,0 +1,103 @@
+package io.worlds.api.model;
+
+import java.util.Objects;
+
+/**
+ * A `H3Cell` represents a geographical area, useful for grouping nearby points.  Refer to [the H3 documentation](https://h3geo.org/docs) for more information on the structure.
+ */
+public class H3Cell implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @jakarta.validation.constraints.NotNull
+    private String index;
+    private GeoJSONPoint center;
+
+    public H3Cell() {
+    }
+
+    public H3Cell(String index, GeoJSONPoint center) {
+        this.index = index;
+        this.center = center;
+    }
+
+    /**
+     * The canonical string index of the cell.  See [the H3 docs](https://h3geo.org/docs/library/index/cell).
+     */
+    public String getIndex() {
+        return index;
+    }
+    /**
+     * The canonical string index of the cell.  See [the H3 docs](https://h3geo.org/docs/library/index/cell).
+     */
+    public void setIndex(String index) {
+        this.index = index;
+    }
+
+    /**
+     * The coordinates of the approximate centroid of the cell.
+     */
+    public GeoJSONPoint getCenter() {
+        return center;
+    }
+    /**
+     * The coordinates of the approximate centroid of the cell.
+     */
+    public void setCenter(GeoJSONPoint center) {
+        this.center = center;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final H3Cell that = (H3Cell) obj;
+        return Objects.equals(index, that.index)
+            && Objects.equals(center, that.center);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, center);
+    }
+
+
+    public static H3Cell.Builder builder() {
+        return new H3Cell.Builder();
+    }
+
+    public static class Builder {
+
+        private String index;
+        private GeoJSONPoint center;
+
+        public Builder() {
+        }
+
+        /**
+         * The canonical string index of the cell.  See [the H3 docs](https://h3geo.org/docs/library/index/cell).
+         */
+        public Builder setIndex(String index) {
+            this.index = index;
+            return this;
+        }
+
+        /**
+         * The coordinates of the approximate centroid of the cell.
+         */
+        public Builder setCenter(GeoJSONPoint center) {
+            this.center = center;
+            return this;
+        }
+
+
+        public H3Cell build() {
+            return new H3Cell(index, center);
+        }
+
+    }
+}

--- a/java/src/main/java/io/worlds/api/model/H3Cell.java
+++ b/java/src/main/java/io/worlds/api/model/H3Cell.java
@@ -22,13 +22,13 @@ public class H3Cell implements java.io.Serializable {
     }
 
     /**
-     * The canonical string index of the cell.  See [the H3 docs](https://h3geo.org/docs/library/index/cell).
+     * The canonical string index of the cell.  Can be used with H3 libraries for additional information on the cell's shape, size, and position.  See [the H3 docs](https://h3geo.org/docs/library/index/cell) for more information.
      */
     public String getIndex() {
         return index;
     }
     /**
-     * The canonical string index of the cell.  See [the H3 docs](https://h3geo.org/docs/library/index/cell).
+     * The canonical string index of the cell.  Can be used with H3 libraries for additional information on the cell's shape, size, and position.  See [the H3 docs](https://h3geo.org/docs/library/index/cell) for more information.
      */
     public void setIndex(String index) {
         this.index = index;
@@ -79,7 +79,7 @@ public class H3Cell implements java.io.Serializable {
         }
 
         /**
-         * The canonical string index of the cell.  See [the H3 docs](https://h3geo.org/docs/library/index/cell).
+         * The canonical string index of the cell.  Can be used with H3 libraries for additional information on the cell's shape, size, and position.  See [the H3 docs](https://h3geo.org/docs/library/index/cell) for more information.
          */
         public Builder setIndex(String index) {
             this.index = index;

--- a/java/src/main/java/io/worlds/api/model/PositionBucketPrecision.java
+++ b/java/src/main/java/io/worlds/api/model/PositionBucketPrecision.java
@@ -1,7 +1,9 @@
 package io.worlds.api.model;
 
 /**
- * Indicates the H3 resolution level for position bucketing. Higher resolutions produce smaller cells.
+ * Indicates the resolution level for position bucketing. Higher resolutions produce smaller cells.
+Options will either be a H3 resolution (`RESOLUTION_0` through `RESOLUTION_15`), or a semantic name referring to one of the H3 resolutions.
+On average, the area of a cell divides by 7 at each new resolution.
 Refer to [the H3 docs](https://h3geo.org/docs/core-library/restable) for more detailed statistics on resolution.
  */
 public enum PositionBucketPrecision {
@@ -10,6 +12,10 @@ public enum PositionBucketPrecision {
      * H3 resolution 0 (~4.3 million km² average cell area)
      */
     RESOLUTION_0("RESOLUTION_0"),
+    /**
+     * Extra-large-scale resolution,  ~4.3 million km² per cell. Alias for `RESOLUTION_0`
+     */
+    CONTINENTAL("CONTINENTAL"),
     /**
      * H3 resolution 1 (~600,000 km²)
      */
@@ -27,6 +33,10 @@ public enum PositionBucketPrecision {
      */
     RESOLUTION_4("RESOLUTION_4"),
     /**
+     * Large-scale resolution, ~1,700 km² per cell. Alias for `RESOLUTION_5`
+     */
+    REGIONAL("REGIONAL"),
+    /**
      * H3 resolution 5 (~253 km²)
      */
     RESOLUTION_5("RESOLUTION_5"),
@@ -39,6 +49,10 @@ public enum PositionBucketPrecision {
      */
     RESOLUTION_7("RESOLUTION_7"),
     /**
+     * Medium-scale resolution, ~5 km² per cell. Alias for `RESOLUTION_7`
+     */
+    DISTRICT("DISTRICT"),
+    /**
      * H3 resolution 8 (~0.7 km²)
      */
     RESOLUTION_8("RESOLUTION_8"),
@@ -47,6 +61,10 @@ public enum PositionBucketPrecision {
      */
     RESOLUTION_9("RESOLUTION_9"),
     /**
+     * Small-scale resolution, ~100,000 m² per cell. Alias for `RESOLUTION_9`
+     */
+    NEIGHBORHOOD("NEIGHBORHOOD"),
+    /**
      * H3 resolution 10 (~15,000 m²)
      */
     RESOLUTION_10("RESOLUTION_10"),
@@ -54,6 +72,10 @@ public enum PositionBucketPrecision {
      * H3 resolution 11 (~2,000 m²)
      */
     RESOLUTION_11("RESOLUTION_11"),
+    /**
+     * Small-scale resolution, ~2,000 m² per cell. Alias for `RESOLUTION_11`
+     */
+    BUILDING("BUILDING"),
     /**
      * H3 resolution 12 (~300 m²)
      */

--- a/java/src/main/java/io/worlds/api/model/PositionBucketPrecision.java
+++ b/java/src/main/java/io/worlds/api/model/PositionBucketPrecision.java
@@ -1,0 +1,85 @@
+package io.worlds.api.model;
+
+/**
+ * Indicates the H3 resolution level for position bucketing. Higher resolutions produce smaller cells.
+Refer to [the H3 docs](https://h3geo.org/docs/core-library/restable) for more detailed statistics on resolution.
+ */
+public enum PositionBucketPrecision {
+
+    /**
+     * H3 resolution 0 (~4.3 million km² average cell area)
+     */
+    RESOLUTION_0("RESOLUTION_0"),
+    /**
+     * H3 resolution 1 (~600,000 km²)
+     */
+    RESOLUTION_1("RESOLUTION_1"),
+    /**
+     * H3 resolution 2 (~87,000 km²)
+     */
+    RESOLUTION_2("RESOLUTION_2"),
+    /**
+     * H3 resolution 3 (~12,000 km²)
+     */
+    RESOLUTION_3("RESOLUTION_3"),
+    /**
+     * H3 resolution 4 (~1,770 km²)
+     */
+    RESOLUTION_4("RESOLUTION_4"),
+    /**
+     * H3 resolution 5 (~253 km²)
+     */
+    RESOLUTION_5("RESOLUTION_5"),
+    /**
+     * H3 resolution 6 (~36 km²)
+     */
+    RESOLUTION_6("RESOLUTION_6"),
+    /**
+     * H3 resolution 7 (~5 km²)
+     */
+    RESOLUTION_7("RESOLUTION_7"),
+    /**
+     * H3 resolution 8 (~0.7 km²)
+     */
+    RESOLUTION_8("RESOLUTION_8"),
+    /**
+     * H3 resolution 9 (~0.1 km² or ~100,000 m²)
+     */
+    RESOLUTION_9("RESOLUTION_9"),
+    /**
+     * H3 resolution 10 (~15,000 m²)
+     */
+    RESOLUTION_10("RESOLUTION_10"),
+    /**
+     * H3 resolution 11 (~2,000 m²)
+     */
+    RESOLUTION_11("RESOLUTION_11"),
+    /**
+     * H3 resolution 12 (~300 m²)
+     */
+    RESOLUTION_12("RESOLUTION_12"),
+    /**
+     * H3 resolution 13 (~40 m²)
+     */
+    RESOLUTION_13("RESOLUTION_13"),
+    /**
+     * H3 resolution 14 (~6 m²)
+     */
+    RESOLUTION_14("RESOLUTION_14"),
+    /**
+     * H3 resolution 15 (~0.9 m²)
+     */
+    RESOLUTION_15("RESOLUTION_15");
+
+    private final String graphqlName;
+
+    private PositionBucketPrecision(String graphqlName) {
+        this.graphqlName = graphqlName;
+    }
+
+    @Override
+    public String toString() {
+        return this.graphqlName;
+    }
+
+}

--- a/java/src/main/java/io/worlds/api/model/PositionBucketPrecision.java
+++ b/java/src/main/java/io/worlds/api/model/PositionBucketPrecision.java
@@ -13,7 +13,7 @@ public enum PositionBucketPrecision {
      */
     RESOLUTION_0("RESOLUTION_0"),
     /**
-     * Extra-large-scale resolution,  ~4.3 million km² per cell. Alias for `RESOLUTION_0`
+     * Extra-large-scale resolution, ~4.3 million km² per cell. Alias for `RESOLUTION_0`
      */
     CONTINENTAL("CONTINENTAL"),
     /**


### PR DESCRIPTION
## Description of Changes
- Add `position` filter to `FilterActivityChronicleSummaryInput`, mirroring the existing `FilterActivityChronicleInput`.
- Add `position` to `ActivityChronicleSummaryBucketType`.  Accepts an enum of `RESOLUTION_0` through `RESOLUTION_15`.  Returned key will include both the H3 index and the approximate center of the cell.

## Link to Related Jira Ticket
[CE-4863]

[CE-4863]: https://worlds-io.atlassian.net/browse/CE-4863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ