### PR TITLE
fix(deps): bump jackson-databind 3.1.0 -> 3.1.2 (CE-5619)

### DIFF
--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary

Bumps `tools.jackson.core:jackson-databind` from 3.1.0 to 3.1.2 in `java-client/pom.xml` to close the Jackson Core Document Length Constraint Bypass CVE (Dependabot alert #43).

Jira: [CE-5619](https://worlds-io.atlassian.net/browse/CE-5619)

## Test Plan

- [x] `mvn clean compile` — BUILD SUCCESS
- [x] `mvn test` — BUILD SUCCESS (0 tests; java-client has no unit tests)

[CE-5619]: https://worlds-io.atlassian.net/browse/CE-5619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ