### PR TITLE
REQ-971: Add deleteZone mutation to GraphQL schema

### DIFF
--- a/graphql/api/domains/zone/mutation.graphqls
+++ b/graphql/api/domains/zone/mutation.graphqls
@@ -9,4 +9,9 @@ extend type Mutation {
         """Arguments to update an existing zone."""
         zone: UpdateZoneInput!
     ): Zone
+    """Deletes an existing Zone."""
+    deleteZone(
+        """The unique identifier of the zone to delete."""
+        id: ID!
+    ): Zone
 }


### PR DESCRIPTION
[REQ-971]

Adds `deleteZone(id: ID!): Zone` mutation to the zone GraphQL schema

[REQ-971]: https://worlds-io.atlassian.net/browse/REQ-971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ