### PR TITLE
CE-6618: Add validatedBy to ChronicleValidation

### DIFF
--- a/graphql/api/domains/chronicle/chronicle.graphqls
+++ b/graphql/api/domains/chronicle/chronicle.graphqls
@@ -20,6 +20,8 @@ type ChronicleValidation {
     reason: String
     """Additional details for the chronicle's validation status."""
     details: String
+    """The user which last validated the event, if any."""
+    validatedBy: User
 }
 
 """

--- a/java/src/main/java/io/worlds/api/model/ChronicleValidation.java
+++ b/java/src/main/java/io/worlds/api/model/ChronicleValidation.java
@@ -13,14 +13,16 @@ public class ChronicleValidation implements java.io.Serializable {
     private ChronicleValidationStatus status;
     private String reason;
     private String details;
+    private User validatedBy;
 
     public ChronicleValidation() {
     }
 
-    public ChronicleValidation(ChronicleValidationStatus status, String reason, String details) {
+    public ChronicleValidation(ChronicleValidationStatus status, String reason, String details, User validatedBy) {
         this.status = status;
         this.reason = reason;
         this.details = details;
+        this.validatedBy = validatedBy;
     }
 
     /**
@@ -62,6 +64,19 @@ public class ChronicleValidation implements java.io.Serializable {
         this.details = details;
     }
 
+    /**
+     * The user which last validated the event, if any.
+     */
+    public User getValidatedBy() {
+        return validatedBy;
+    }
+    /**
+     * The user which last validated the event, if any.
+     */
+    public void setValidatedBy(User validatedBy) {
+        this.validatedBy = validatedBy;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -73,12 +88,13 @@ public class ChronicleValidation implements java.io.Serializable {
         final ChronicleValidation that = (ChronicleValidation) obj;
         return Objects.equals(status, that.status)
             && Objects.equals(reason, that.reason)
-            && Objects.equals(details, that.details);
+            && Objects.equals(details, that.details)
+            && Objects.equals(validatedBy, that.validatedBy);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(status, reason, details);
+        return Objects.hash(status, reason, details, validatedBy);
     }
 
 
@@ -91,6 +107,7 @@ public class ChronicleValidation implements java.io.Serializable {
         private ChronicleValidationStatus status;
         private String reason;
         private String details;
+        private User validatedBy;
 
         public Builder() {
         }
@@ -119,9 +136,17 @@ public class ChronicleValidation implements java.io.Serializable {
             return this;
         }
 
+        /**
+         * The user which last validated the event, if any.
+         */
+        public Builder setValidatedBy(User validatedBy) {
+            this.validatedBy = validatedBy;
+            return this;
+        }
+
 
         public ChronicleValidation build() {
-            return new ChronicleValidation(status, reason, details);
+            return new ChronicleValidation(status, reason, details, validatedBy);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/PositionBucketPrecision.java
+++ b/java/src/main/java/io/worlds/api/model/PositionBucketPrecision.java
@@ -73,13 +73,13 @@ public enum PositionBucketPrecision {
      */
     RESOLUTION_11("RESOLUTION_11"),
     /**
-     * Small-scale resolution, ~2,000 m² per cell. Alias for `RESOLUTION_11`
-     */
-    BUILDING("BUILDING"),
-    /**
      * H3 resolution 12 (~300 m²)
      */
     RESOLUTION_12("RESOLUTION_12"),
+    /**
+     * Small-scale resolution, ~300 m² per cell. Alias for `RESOLUTION_12`
+     */
+    BUILDING("BUILDING"),
     /**
      * H3 resolution 13 (~40 m²)
      */


### PR DESCRIPTION
## Description of Changes
Add `validatedBy` to `ChronicleValidation`.  Value populates on write from user's JWT, if present.

## Link to Related Jira Ticket
[CE-6618]

[CE-6618]: https://worlds-io.atlassian.net/browse/CE-6618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ