### PR TITLE
feat: CE-5201: Add FilterSiteInput to device and device summary filters

### DIFF
--- a/graphql/api/domains/devices/filter.graphqls
+++ b/graphql/api/domains/devices/filter.graphqls
@@ -28,6 +28,10 @@ input FilterDeviceInput {
     """
     enabled: FilterBooleanInput
     """
+    If provided, specifies filters that work against the device's site.
+    """
+    site: FilterSiteInput
+    """
     If provided, a device must pass all filters in this list to match the current filter.
     """
     and: [FilterDeviceInput!]

--- a/graphql/api/domains/summary/filter.graphqls
+++ b/graphql/api/domains/summary/filter.graphqls
@@ -182,6 +182,10 @@ input FilterDeviceSummaryInput {
     """
     siteId: FilterIDInput
     """
+    If provided, specifies filters that work against the device's site.
+    """
+    site: FilterSiteInput
+    """
     If provided, specifies filters that work against the point of interest ID of the device.
     """
     pointOfInterestId: FilterIDInput

--- a/java/src/main/java/io/worlds/api/model/FilterDeviceInput.java
+++ b/java/src/main/java/io/worlds/api/model/FilterDeviceInput.java
@@ -16,6 +16,7 @@ public class FilterDeviceInput implements java.io.Serializable {
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> externalId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> address = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> enabled = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<FilterSiteInput> site = org.springframework.graphql.data.ArgumentValue.omitted();
     private java.util.List<FilterDeviceInput> and;
     private java.util.List<FilterDeviceInput> or;
     private org.springframework.graphql.data.ArgumentValue<FilterDeviceInput> not = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -23,13 +24,14 @@ public class FilterDeviceInput implements java.io.Serializable {
     public FilterDeviceInput() {
     }
 
-    public FilterDeviceInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterIDInput> uuid, org.springframework.graphql.data.ArgumentValue<FilterStringInput> name, org.springframework.graphql.data.ArgumentValue<FilterStringInput> externalId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> address, org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> enabled, java.util.List<FilterDeviceInput> and, java.util.List<FilterDeviceInput> or, org.springframework.graphql.data.ArgumentValue<FilterDeviceInput> not) {
+    public FilterDeviceInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterIDInput> uuid, org.springframework.graphql.data.ArgumentValue<FilterStringInput> name, org.springframework.graphql.data.ArgumentValue<FilterStringInput> externalId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> address, org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> enabled, org.springframework.graphql.data.ArgumentValue<FilterSiteInput> site, java.util.List<FilterDeviceInput> and, java.util.List<FilterDeviceInput> or, org.springframework.graphql.data.ArgumentValue<FilterDeviceInput> not) {
         this.id = id;
         this.uuid = uuid;
         this.name = name;
         this.externalId = externalId;
         this.address = address;
         this.enabled = enabled;
+        this.site = site;
         this.and = and;
         this.or = or;
         this.not = not;
@@ -77,6 +79,13 @@ public class FilterDeviceInput implements java.io.Serializable {
         this.enabled = enabled;
     }
 
+    public org.springframework.graphql.data.ArgumentValue<FilterSiteInput> getSite() {
+        return site;
+    }
+    public void setSite(org.springframework.graphql.data.ArgumentValue<FilterSiteInput> site) {
+        this.site = site;
+    }
+
     public java.util.List<FilterDeviceInput> getAnd() {
         return and;
     }
@@ -113,6 +122,7 @@ public class FilterDeviceInput implements java.io.Serializable {
             && Objects.equals(externalId, that.externalId)
             && Objects.equals(address, that.address)
             && Objects.equals(enabled, that.enabled)
+            && Objects.equals(site, that.site)
             && Objects.equals(and, that.and)
             && Objects.equals(or, that.or)
             && Objects.equals(not, that.not);
@@ -120,7 +130,7 @@ public class FilterDeviceInput implements java.io.Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, uuid, name, externalId, address, enabled, and, or, not);
+        return Objects.hash(id, uuid, name, externalId, address, enabled, site, and, or, not);
     }
 
 
@@ -136,6 +146,7 @@ public class FilterDeviceInput implements java.io.Serializable {
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> externalId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> address = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterBooleanInput> enabled = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<FilterSiteInput> site = org.springframework.graphql.data.ArgumentValue.omitted();
         private java.util.List<FilterDeviceInput> and;
         private java.util.List<FilterDeviceInput> or;
         private org.springframework.graphql.data.ArgumentValue<FilterDeviceInput> not = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -173,6 +184,11 @@ public class FilterDeviceInput implements java.io.Serializable {
             return this;
         }
 
+        public Builder setSite(org.springframework.graphql.data.ArgumentValue<FilterSiteInput> site) {
+            this.site = site;
+            return this;
+        }
+
         public Builder setAnd(java.util.List<FilterDeviceInput> and) {
             this.and = and;
             return this;
@@ -190,7 +206,7 @@ public class FilterDeviceInput implements java.io.Serializable {
 
 
         public FilterDeviceInput build() {
-            return new FilterDeviceInput(id, uuid, name, externalId, address, enabled, and, or, not);
+            return new FilterDeviceInput(id, uuid, name, externalId, address, enabled, site, and, or, not);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/FilterDeviceSummaryInput.java
+++ b/java/src/main/java/io/worlds/api/model/FilterDeviceSummaryInput.java
@@ -11,6 +11,7 @@ public class FilterDeviceSummaryInput implements java.io.Serializable {
     private static final long serialVersionUID = 1L;
 
     private org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<FilterSiteInput> site = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId = org.springframework.graphql.data.ArgumentValue.omitted();
     private java.util.List<FilterDeviceSummaryInput> and;
     private java.util.List<FilterDeviceSummaryInput> or;
@@ -19,8 +20,9 @@ public class FilterDeviceSummaryInput implements java.io.Serializable {
     public FilterDeviceSummaryInput() {
     }
 
-    public FilterDeviceSummaryInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId, org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId, java.util.List<FilterDeviceSummaryInput> and, java.util.List<FilterDeviceSummaryInput> or, org.springframework.graphql.data.ArgumentValue<FilterDeviceSummaryInput> not) {
+    public FilterDeviceSummaryInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId, org.springframework.graphql.data.ArgumentValue<FilterSiteInput> site, org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId, java.util.List<FilterDeviceSummaryInput> and, java.util.List<FilterDeviceSummaryInput> or, org.springframework.graphql.data.ArgumentValue<FilterDeviceSummaryInput> not) {
         this.siteId = siteId;
+        this.site = site;
         this.pointOfInterestId = pointOfInterestId;
         this.and = and;
         this.or = or;
@@ -32,6 +34,13 @@ public class FilterDeviceSummaryInput implements java.io.Serializable {
     }
     public void setSiteId(org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId) {
         this.siteId = siteId;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<FilterSiteInput> getSite() {
+        return site;
+    }
+    public void setSite(org.springframework.graphql.data.ArgumentValue<FilterSiteInput> site) {
+        this.site = site;
     }
 
     public org.springframework.graphql.data.ArgumentValue<FilterIDInput> getPointOfInterestId() {
@@ -72,6 +81,7 @@ public class FilterDeviceSummaryInput implements java.io.Serializable {
         }
         final FilterDeviceSummaryInput that = (FilterDeviceSummaryInput) obj;
         return Objects.equals(siteId, that.siteId)
+            && Objects.equals(site, that.site)
             && Objects.equals(pointOfInterestId, that.pointOfInterestId)
             && Objects.equals(and, that.and)
             && Objects.equals(or, that.or)
@@ -80,7 +90,7 @@ public class FilterDeviceSummaryInput implements java.io.Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(siteId, pointOfInterestId, and, or, not);
+        return Objects.hash(siteId, site, pointOfInterestId, and, or, not);
     }
 
 
@@ -91,6 +101,7 @@ public class FilterDeviceSummaryInput implements java.io.Serializable {
     public static class Builder {
 
         private org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<FilterSiteInput> site = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId = org.springframework.graphql.data.ArgumentValue.omitted();
         private java.util.List<FilterDeviceSummaryInput> and;
         private java.util.List<FilterDeviceSummaryInput> or;
@@ -101,6 +112,11 @@ public class FilterDeviceSummaryInput implements java.io.Serializable {
 
         public Builder setSiteId(org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId) {
             this.siteId = siteId;
+            return this;
+        }
+
+        public Builder setSite(org.springframework.graphql.data.ArgumentValue<FilterSiteInput> site) {
+            this.site = site;
             return this;
         }
 
@@ -126,7 +142,7 @@ public class FilterDeviceSummaryInput implements java.io.Serializable {
 
 
         public FilterDeviceSummaryInput build() {
-            return new FilterDeviceSummaryInput(siteId, pointOfInterestId, and, or, not);
+            return new FilterDeviceSummaryInput(siteId, site, pointOfInterestId, and, or, not);
         }
 
     }


### PR DESCRIPTION
## Summary
- Expose a `site: FilterSiteInput` field on `FilterDeviceInput` and `FilterDeviceSummaryInput` so clients can filter devices and device summaries by site attributes (not just site ID).

## Test plan
- [ ] Schema compiles and generated Java models build cleanly
- [ ] Query devices/deviceSummaries with a nested `site` filter and verify expected results

[CE-5201]

[CE-5201]: https://worlds-io.atlassian.net/browse/CE-5201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ