### PR TITLE
fix(deps): override netty to 4.2.13.Final to fix 12 security vulnerabilities

### DIFF
--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -14,6 +14,24 @@
         <maven.compiler.target>21</maven.compiler.target>
         <java.version>21</java.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <!--
+              Override Netty to 4.2.13.Final to close 12 Dependabot alerts (high/medium/low):
+              HTTP request smuggling, decompression bomb DoS, QPACK unbounded allocation,
+              epoll DoS, DNS codec bypass, HTTP/3 codec, handler-proxy, and more.
+              reactor-netty-http 1.3.5 ships netty 4.2.12.Final.
+              Remove when reactor-netty-http ships netty >= 4.2.13.Final.
+            -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.2.13.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.worlds</groupId>


### PR DESCRIPTION
## Summary

Adds a Netty BOM override to `java-client/pom.xml` to bump all transitive Netty artifacts from 4.2.12.Final to 4.2.13.Final, resolving all 12 open Dependabot alerts:

- CVE-2026-42587: HTTP request smuggling via `netty-codec-http`/`netty-codec-http2` (high)
- CVE-2026-42584: `netty-codec-http` vulnerability (high)
- CVE-2026-42583: `netty-codec-compression` decompression bomb DoS (high)
- CVE-2026-42582: `netty-codec-http3` vulnerability (high)
- CVE-2026-42579: `netty-codec-dns` bypass (high)
- CVE-2026-42577: `netty-transport-native-epoll` DoS (high)
- CVE-2026-42585: `netty-codec-http` (medium)
- CVE-2026-42581: `netty-codec-http` (medium)
- CVE-2026-42580: `netty-codec-http` (medium)
- CVE-2026-41417: `netty-codec-http` (medium)
- CVE-2026-42578: `netty-handler-proxy` (low)

`reactor-netty-http` 1.3.5 ships Netty 4.2.12.Final; no 1.3.6 release exists yet, so the BOM override is required.

## Test plan

- [x] `mvn clean compile` succeeds for both `java` and `java-client` modules
- [x] `mvn test` passes in `java-client`
- [x] `mvn dependency:tree` confirms all Netty artifacts resolve to 4.2.13.Final

🤖 Generated with [Claude Code](https://claude.com/claude-code)