### PR TITLE
feat: CE-8301: Add highestTotalBuckets to all summary types

### DIFF
--- a/graphql/api/domains/summary/summary.graphqls
+++ b/graphql/api/domains/summary/summary.graphqls
@@ -21,6 +21,30 @@ type TracksSummary {
     Summary buckets are only returned if `bucket` is provided as a query parameter to [`tracksSummary`]({{Queries.tracksSummary}}).
     """
     buckets: [TracksSummaryBucket!]
+    """
+    The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `tracksBucket`
+    was provided.  All tied buckets are returned per group.
+    """
+    highestTotalBuckets(
+        """
+        Dimensions to keep distinct when finding the max.  Must align with the query's `tracksBucket`:
+        `groupBy.fields` must be a subset of `tracksBucket.fields`, and `groupBy.size` must equal
+        `tracksBucket.size` if set.  If null, returns the single bucket with the greatest total
+        across all buckets (plus any ties).
+        """
+        groupBy: TracksSummaryBucketType
+    ): [TracksHighestTotalBucket!]!
+}
+
+"""
+A bucket selected as having the greatest `total` within its group, returned from
+[`TracksSummary.highestTotalBuckets`]({{Types.TracksSummary}}).
+"""
+type TracksHighestTotalBucket {
+    """The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null."""
+    key: TracksSummaryBucketKey!
+    """The total number of [Tracks]({{Types.Track}}) in the winning bucket."""
+    total: Int!
 }
 
 type TracksCountByTag {

--- a/graphql/api/domains/summary/summary.graphqls
+++ b/graphql/api/domains/summary/summary.graphqls
@@ -107,10 +107,34 @@ type EventsSummary {
     """
     buckets: [EventsSummaryBucket!]
     """
+    The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `eventsBucket`
+    was provided.  All tied buckets are returned per group.
+    """
+    highestTotalBuckets(
+        """
+        Dimensions to keep distinct when finding the max.  Must align with the query's `eventsBucket`:
+        `groupBy.fields` must be a subset of `eventsBucket.fields`, and `groupBy.size` must equal
+        `eventsBucket.size` if set.  If null, returns the single bucket with the greatest total
+        across all buckets (plus any ties).
+        """
+        groupBy: EventsSummaryBucketType
+    ): [EventsHighestTotalBucket!]!
+    """
     The distinct top-level keys found in the `metadata` field across all matching events.
     Useful for discovering available metadata keys that can be used for metadata bucketing.
     """
     metadataKeys: [String!]
+}
+
+"""
+A bucket selected as having the greatest `total` within its group, returned from
+[`EventsSummary.highestTotalBuckets`]({{Types.EventsSummary}}).
+"""
+type EventsHighestTotalBucket {
+    """The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null."""
+    key: EventsSummaryBucketKey!
+    """The total number of [Events]({{Types.Event}}) in the winning bucket."""
+    total: Int!
 }
 
 """
@@ -165,6 +189,30 @@ type VideosSummary {
     Summary buckets are only returned if `bucket` is provided as a query parameter to [`videosSummary`]({{Queries.videosSummary}}).
     """
     buckets: [VideosSummaryBucket!]
+    """
+    The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `videosBucket`
+    was provided.  All tied buckets are returned per group.
+    """
+    highestTotalBuckets(
+        """
+        Dimensions to keep distinct when finding the max.  Must align with the query's `videosBucket`:
+        `groupBy.fields` must be a subset of `videosBucket.fields`, and `groupBy.size` must equal
+        `videosBucket.size` if set.  If null, returns the single bucket with the greatest total
+        across all buckets (plus any ties).
+        """
+        groupBy: VideosSummaryBucketType
+    ): [VideosHighestTotalBucket!]!
+}
+
+"""
+A bucket selected as having the greatest `total` within its group, returned from
+[`VideosSummary.highestTotalBuckets`]({{Types.VideosSummary}}).
+"""
+type VideosHighestTotalBucket {
+    """The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null."""
+    key: VideosSummaryBucketKey!
+    """The total number of [Videos]({{Types.Video}}) in the winning bucket."""
+    total: Int!
 }
 
 """
@@ -193,10 +241,34 @@ type ActivityChronicleSummary {
     """
     buckets: [ActivityChronicleSummaryBucket!]
     """
+    The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `activityChronicleBucket`
+    was provided.  All tied buckets are returned per group.
+    """
+    highestTotalBuckets(
+        """
+        Dimensions to keep distinct when finding the max.  Must align with the query's `activityChronicleBucket`:
+        `groupBy.fields` must be a subset of `activityChronicleBucket.fields`, and `groupBy.size` must equal
+        `activityChronicleBucket.size` if set.  If null, returns the single bucket with the greatest total
+        across all buckets (plus any ties).
+        """
+        groupBy: ActivityChronicleSummaryBucketType
+    ): [ActivityChronicleHighestTotalBucket!]!
+    """
     The distinct top-level keys found in the `metadata` field across all matching activity chronicles.
     Useful for discovering available metadata keys that can be used for metadata bucketing.
     """
     metadataKeys: [String!]
+}
+
+"""
+A bucket selected as having the greatest `total` within its group, returned from
+[`ActivityChronicleSummary.highestTotalBuckets`]({{Types.ActivityChronicleSummary}}).
+"""
+type ActivityChronicleHighestTotalBucket {
+    """The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null."""
+    key: ActivityChronicleSummaryBucketKey!
+    """The total number of activity chronicles in the winning bucket."""
+    total: Int!
 }
 
 """
@@ -312,6 +384,30 @@ type ZoneIntersectionSummary {
     Summary buckets are only returned if `zoneIntersectionBucket` is provided as a query parameter to `zoneIntersectionSummary`.
     """
     buckets: [ZoneIntersectionSummaryBucket!]
+    """
+    The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `zoneIntersectionBucket`
+    was provided.  All tied buckets are returned per group.
+    """
+    highestTotalBuckets(
+        """
+        Dimensions to keep distinct when finding the max.  Must align with the query's `zoneIntersectionBucket`:
+        `groupBy.fields` must be a subset of `zoneIntersectionBucket.fields`, and `groupBy.size` must equal
+        `zoneIntersectionBucket.size` if set.  If null, returns the single bucket with the greatest total
+        across all buckets (plus any ties).
+        """
+        groupBy: ZoneIntersectionSummaryBucketType
+    ): [ZoneIntersectionHighestTotalBucket!]!
+}
+
+"""
+A bucket selected as having the greatest `total` within its group, returned from
+[`ZoneIntersectionSummary.highestTotalBuckets`]({{Types.ZoneIntersectionSummary}}).
+"""
+type ZoneIntersectionHighestTotalBucket {
+    """The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null."""
+    key: ZoneIntersectionSummaryBucketKey!
+    """The total number of zone intersections in the winning bucket."""
+    total: Int!
 }
 
 """
@@ -359,6 +455,30 @@ type DetectionsSummary {
     Summary buckets are only returned if `detectionsBucket` is provided as a query parameter to `detectionsSummary`.
     """
     buckets: [DetectionsSummaryBucket!]
+    """
+    The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `detectionsBucket`
+    was provided.  All tied buckets are returned per group.
+    """
+    highestTotalBuckets(
+        """
+        Dimensions to keep distinct when finding the max.  Must align with the query's `detectionsBucket`:
+        `groupBy.fields` must be a subset of `detectionsBucket.fields`, and `groupBy.size` must equal
+        `detectionsBucket.size` if set.  If null, returns the single bucket with the greatest total
+        across all buckets (plus any ties).
+        """
+        groupBy: DetectionsSummaryBucketType
+    ): [DetectionsHighestTotalBucket!]!
+}
+
+"""
+A bucket selected as having the greatest `total` within its group, returned from
+[`DetectionsSummary.highestTotalBuckets`]({{Types.DetectionsSummary}}).
+"""
+type DetectionsHighestTotalBucket {
+    """The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null."""
+    key: DetectionsSummaryBucketKey!
+    """The total number of detections in the winning bucket."""
+    total: Int!
 }
 
 """
@@ -386,6 +506,30 @@ type DeviceSummary {
     Summary buckets are only returned if `deviceBucket` is provided as a query parameter to `deviceSummary`.
     """
     buckets: [DeviceSummaryBucket!]
+    """
+    The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `deviceBucket`
+    was provided.  All tied buckets are returned per group.
+    """
+    highestTotalBuckets(
+        """
+        Dimensions to keep distinct when finding the max.  Must align with the query's `deviceBucket`:
+        `groupBy.fields` must be a subset of `deviceBucket.fields`, and `groupBy.size` must equal
+        `deviceBucket.size` if set.  If null, returns the single bucket with the greatest total
+        across all buckets (plus any ties).
+        """
+        groupBy: DeviceSummaryBucketType
+    ): [DeviceHighestTotalBucket!]!
+}
+
+"""
+A bucket selected as having the greatest `total` within its group, returned from
+[`DeviceSummary.highestTotalBuckets`]({{Types.DeviceSummary}}).
+"""
+type DeviceHighestTotalBucket {
+    """The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null."""
+    key: DeviceSummaryBucketKey!
+    """The total number of devices in the winning bucket."""
+    total: Int!
 }
 
 """

--- a/graphql/api/domains/summary/summary.graphqls
+++ b/graphql/api/domains/summary/summary.graphqls
@@ -196,8 +196,8 @@ type VideosSummary {
     highestTotalBuckets(
         """
         Dimensions to keep distinct when finding the max.  Must align with the query's `videosBucket`:
-        `groupBy.fields` must be a subset of `videosBucket.fields`, and `groupBy.size` must equal
-        `videosBucket.size` if set.  If null, returns the single bucket with the greatest total
+        `groupBy.fields` must be a subset of `videosBucket.fields`
+        If null, returns the single bucket with the greatest total
         across all buckets (plus any ties).
         """
         groupBy: VideosSummaryBucketType

--- a/graphql/api/domains/summary/summary.graphqls
+++ b/graphql/api/domains/summary/summary.graphqls
@@ -18,7 +18,7 @@ type TracksSummary {
     totalsByTag: [TracksCountByTag!]! @deprecated(reason: "To retrieve per-tag counts, group by the `TAG` field, either alone or in combination with a time bucket.  Counts will return as empty if a `tracksBucket` or `filter` is used.")
     """
     A detailed summary of each [bucket]({{Types.SummaryBucketSize}}) within the time range.
-    Summary buckets are only returned if `bucket` is provided as a query parameter to [`tracksSummary`]({{Queries.tracksSummary}}).
+    Summary buckets are only returned if `tracksBucket` is provided as a query parameter to [`tracksSummary`]({{Queries.tracksSummary}}).
     """
     buckets: [TracksSummaryBucket!]
     """
@@ -103,7 +103,7 @@ type EventsSummary {
     summaryStatistics: EventsSummaryStatistics!
     """
     A detailed summary of each [bucket]({{Types.SummaryBucketSize}}) within the time range.
-    Summary buckets are only returned if `bucket` is provided as a query parameter to [`eventsSummary`]({{Queries.eventsSummary}}).
+    Summary buckets are only returned if `eventsBucket` is provided as a query parameter to [`eventsSummary`]({{Queries.eventsSummary}}).
     """
     buckets: [EventsSummaryBucket!]
     """
@@ -186,7 +186,7 @@ type VideosSummary {
     summaryStatistics: VideosSummaryStatistics!
     """
     A detailed summary of each [bucket]({{Types.SummaryBucketSize}}) within the time range.
-    Summary buckets are only returned if `bucket` is provided as a query parameter to [`videosSummary`]({{Queries.videosSummary}}).
+    Summary buckets are only returned if `videosBucket` is provided as a query parameter to [`videosSummary`]({{Queries.videosSummary}}).
     """
     buckets: [VideosSummaryBucket!]
     """

--- a/graphql/api/domains/summary/util.graphqls
+++ b/graphql/api/domains/summary/util.graphqls
@@ -353,7 +353,7 @@ type TracksSummaryBucketKey {
     """The site for data sources which produced the tracks."""
     dataSourceSite: Site
     """The point of interest for data sources which produced the tracks."""
-    dataSourcePointOfInterest: Site
+    dataSourcePointOfInterest: PointOfInterest
 }
 
 """The grouping key for an VideosSummaryBucket.  Fields bucketed on will be present.  All other fields will be null."""

--- a/java/src/main/java/io/worlds/api/model/ActivityChronicleHighestTotalBucket.java
+++ b/java/src/main/java/io/worlds/api/model/ActivityChronicleHighestTotalBucket.java
@@ -1,0 +1,104 @@
+package io.worlds.api.model;
+
+import java.util.Objects;
+
+/**
+ * A bucket selected as having the greatest `total` within its group, returned from
+[`ActivityChronicleSummary.highestTotalBuckets`]({{Types.ActivityChronicleSummary}}).
+ */
+public class ActivityChronicleHighestTotalBucket implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @jakarta.validation.constraints.NotNull
+    private ActivityChronicleSummaryBucketKey key;
+    private int total;
+
+    public ActivityChronicleHighestTotalBucket() {
+    }
+
+    public ActivityChronicleHighestTotalBucket(ActivityChronicleSummaryBucketKey key, int total) {
+        this.key = key;
+        this.total = total;
+    }
+
+    /**
+     * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+     */
+    public ActivityChronicleSummaryBucketKey getKey() {
+        return key;
+    }
+    /**
+     * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+     */
+    public void setKey(ActivityChronicleSummaryBucketKey key) {
+        this.key = key;
+    }
+
+    /**
+     * The total number of activity chronicles in the winning bucket.
+     */
+    public int getTotal() {
+        return total;
+    }
+    /**
+     * The total number of activity chronicles in the winning bucket.
+     */
+    public void setTotal(int total) {
+        this.total = total;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final ActivityChronicleHighestTotalBucket that = (ActivityChronicleHighestTotalBucket) obj;
+        return Objects.equals(key, that.key)
+            && Objects.equals(total, that.total);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, total);
+    }
+
+
+    public static ActivityChronicleHighestTotalBucket.Builder builder() {
+        return new ActivityChronicleHighestTotalBucket.Builder();
+    }
+
+    public static class Builder {
+
+        private ActivityChronicleSummaryBucketKey key;
+        private int total;
+
+        public Builder() {
+        }
+
+        /**
+         * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+         */
+        public Builder setKey(ActivityChronicleSummaryBucketKey key) {
+            this.key = key;
+            return this;
+        }
+
+        /**
+         * The total number of activity chronicles in the winning bucket.
+         */
+        public Builder setTotal(int total) {
+            this.total = total;
+            return this;
+        }
+
+
+        public ActivityChronicleHighestTotalBucket build() {
+            return new ActivityChronicleHighestTotalBucket(key, total);
+        }
+
+    }
+}

--- a/java/src/main/java/io/worlds/api/model/ActivityChronicleSummary.java
+++ b/java/src/main/java/io/worlds/api/model/ActivityChronicleSummary.java
@@ -15,17 +15,20 @@ public class ActivityChronicleSummary implements java.io.Serializable {
     @jakarta.validation.constraints.NotNull
     private ActivityChronicleSummaryStatistics summaryStatistics;
     private java.util.List<ActivityChronicleSummaryBucket> buckets;
+    @jakarta.validation.constraints.NotNull
+    private java.util.List<ActivityChronicleHighestTotalBucket> highestTotalBuckets;
     private java.util.List<String> metadataKeys;
 
     public ActivityChronicleSummary() {
     }
 
-    public ActivityChronicleSummary(int total, int startedCount, int endedCount, ActivityChronicleSummaryStatistics summaryStatistics, java.util.List<ActivityChronicleSummaryBucket> buckets, java.util.List<String> metadataKeys) {
+    public ActivityChronicleSummary(int total, int startedCount, int endedCount, ActivityChronicleSummaryStatistics summaryStatistics, java.util.List<ActivityChronicleSummaryBucket> buckets, java.util.List<ActivityChronicleHighestTotalBucket> highestTotalBuckets, java.util.List<String> metadataKeys) {
         this.total = total;
         this.startedCount = startedCount;
         this.endedCount = endedCount;
         this.summaryStatistics = summaryStatistics;
         this.buckets = buckets;
+        this.highestTotalBuckets = highestTotalBuckets;
         this.metadataKeys = metadataKeys;
     }
 
@@ -97,6 +100,21 @@ Summary buckets are only returned if `activityChronicleBucket` is provided as a 
     }
 
     /**
+     * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `activityChronicleBucket`
+was provided.  All tied buckets are returned per group.
+     */
+    public java.util.List<ActivityChronicleHighestTotalBucket> getHighestTotalBuckets() {
+        return highestTotalBuckets;
+    }
+    /**
+     * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `activityChronicleBucket`
+was provided.  All tied buckets are returned per group.
+     */
+    public void setHighestTotalBuckets(java.util.List<ActivityChronicleHighestTotalBucket> highestTotalBuckets) {
+        this.highestTotalBuckets = highestTotalBuckets;
+    }
+
+    /**
      * The distinct top-level keys found in the `metadata` field across all matching activity chronicles.
 Useful for discovering available metadata keys that can be used for metadata bucketing.
      */
@@ -125,12 +143,13 @@ Useful for discovering available metadata keys that can be used for metadata buc
             && Objects.equals(endedCount, that.endedCount)
             && Objects.equals(summaryStatistics, that.summaryStatistics)
             && Objects.equals(buckets, that.buckets)
+            && Objects.equals(highestTotalBuckets, that.highestTotalBuckets)
             && Objects.equals(metadataKeys, that.metadataKeys);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(total, startedCount, endedCount, summaryStatistics, buckets, metadataKeys);
+        return Objects.hash(total, startedCount, endedCount, summaryStatistics, buckets, highestTotalBuckets, metadataKeys);
     }
 
 
@@ -145,6 +164,7 @@ Useful for discovering available metadata keys that can be used for metadata buc
         private int endedCount;
         private ActivityChronicleSummaryStatistics summaryStatistics;
         private java.util.List<ActivityChronicleSummaryBucket> buckets;
+        private java.util.List<ActivityChronicleHighestTotalBucket> highestTotalBuckets;
         private java.util.List<String> metadataKeys;
 
         public Builder() {
@@ -192,6 +212,15 @@ Summary buckets are only returned if `activityChronicleBucket` is provided as a 
         }
 
         /**
+         * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `activityChronicleBucket`
+was provided.  All tied buckets are returned per group.
+         */
+        public Builder setHighestTotalBuckets(java.util.List<ActivityChronicleHighestTotalBucket> highestTotalBuckets) {
+            this.highestTotalBuckets = highestTotalBuckets;
+            return this;
+        }
+
+        /**
          * The distinct top-level keys found in the `metadata` field across all matching activity chronicles.
 Useful for discovering available metadata keys that can be used for metadata bucketing.
          */
@@ -202,7 +231,7 @@ Useful for discovering available metadata keys that can be used for metadata buc
 
 
         public ActivityChronicleSummary build() {
-            return new ActivityChronicleSummary(total, startedCount, endedCount, summaryStatistics, buckets, metadataKeys);
+            return new ActivityChronicleSummary(total, startedCount, endedCount, summaryStatistics, buckets, highestTotalBuckets, metadataKeys);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/DetectionsHighestTotalBucket.java
+++ b/java/src/main/java/io/worlds/api/model/DetectionsHighestTotalBucket.java
@@ -1,0 +1,104 @@
+package io.worlds.api.model;
+
+import java.util.Objects;
+
+/**
+ * A bucket selected as having the greatest `total` within its group, returned from
+[`DetectionsSummary.highestTotalBuckets`]({{Types.DetectionsSummary}}).
+ */
+public class DetectionsHighestTotalBucket implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @jakarta.validation.constraints.NotNull
+    private DetectionsSummaryBucketKey key;
+    private int total;
+
+    public DetectionsHighestTotalBucket() {
+    }
+
+    public DetectionsHighestTotalBucket(DetectionsSummaryBucketKey key, int total) {
+        this.key = key;
+        this.total = total;
+    }
+
+    /**
+     * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+     */
+    public DetectionsSummaryBucketKey getKey() {
+        return key;
+    }
+    /**
+     * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+     */
+    public void setKey(DetectionsSummaryBucketKey key) {
+        this.key = key;
+    }
+
+    /**
+     * The total number of detections in the winning bucket.
+     */
+    public int getTotal() {
+        return total;
+    }
+    /**
+     * The total number of detections in the winning bucket.
+     */
+    public void setTotal(int total) {
+        this.total = total;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final DetectionsHighestTotalBucket that = (DetectionsHighestTotalBucket) obj;
+        return Objects.equals(key, that.key)
+            && Objects.equals(total, that.total);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, total);
+    }
+
+
+    public static DetectionsHighestTotalBucket.Builder builder() {
+        return new DetectionsHighestTotalBucket.Builder();
+    }
+
+    public static class Builder {
+
+        private DetectionsSummaryBucketKey key;
+        private int total;
+
+        public Builder() {
+        }
+
+        /**
+         * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+         */
+        public Builder setKey(DetectionsSummaryBucketKey key) {
+            this.key = key;
+            return this;
+        }
+
+        /**
+         * The total number of detections in the winning bucket.
+         */
+        public Builder setTotal(int total) {
+            this.total = total;
+            return this;
+        }
+
+
+        public DetectionsHighestTotalBucket build() {
+            return new DetectionsHighestTotalBucket(key, total);
+        }
+
+    }
+}

--- a/java/src/main/java/io/worlds/api/model/DetectionsSummary.java
+++ b/java/src/main/java/io/worlds/api/model/DetectionsSummary.java
@@ -11,13 +11,16 @@ public class DetectionsSummary implements java.io.Serializable {
 
     private int total;
     private java.util.List<DetectionsSummaryBucket> buckets;
+    @jakarta.validation.constraints.NotNull
+    private java.util.List<DetectionsHighestTotalBucket> highestTotalBuckets;
 
     public DetectionsSummary() {
     }
 
-    public DetectionsSummary(int total, java.util.List<DetectionsSummaryBucket> buckets) {
+    public DetectionsSummary(int total, java.util.List<DetectionsSummaryBucket> buckets, java.util.List<DetectionsHighestTotalBucket> highestTotalBuckets) {
         this.total = total;
         this.buckets = buckets;
+        this.highestTotalBuckets = highestTotalBuckets;
     }
 
     /**
@@ -48,6 +51,21 @@ Summary buckets are only returned if `detectionsBucket` is provided as a query p
         this.buckets = buckets;
     }
 
+    /**
+     * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `detectionsBucket`
+was provided.  All tied buckets are returned per group.
+     */
+    public java.util.List<DetectionsHighestTotalBucket> getHighestTotalBuckets() {
+        return highestTotalBuckets;
+    }
+    /**
+     * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `detectionsBucket`
+was provided.  All tied buckets are returned per group.
+     */
+    public void setHighestTotalBuckets(java.util.List<DetectionsHighestTotalBucket> highestTotalBuckets) {
+        this.highestTotalBuckets = highestTotalBuckets;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -58,12 +76,13 @@ Summary buckets are only returned if `detectionsBucket` is provided as a query p
         }
         final DetectionsSummary that = (DetectionsSummary) obj;
         return Objects.equals(total, that.total)
-            && Objects.equals(buckets, that.buckets);
+            && Objects.equals(buckets, that.buckets)
+            && Objects.equals(highestTotalBuckets, that.highestTotalBuckets);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(total, buckets);
+        return Objects.hash(total, buckets, highestTotalBuckets);
     }
 
 
@@ -75,6 +94,7 @@ Summary buckets are only returned if `detectionsBucket` is provided as a query p
 
         private int total;
         private java.util.List<DetectionsSummaryBucket> buckets;
+        private java.util.List<DetectionsHighestTotalBucket> highestTotalBuckets;
 
         public Builder() {
         }
@@ -96,9 +116,18 @@ Summary buckets are only returned if `detectionsBucket` is provided as a query p
             return this;
         }
 
+        /**
+         * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `detectionsBucket`
+was provided.  All tied buckets are returned per group.
+         */
+        public Builder setHighestTotalBuckets(java.util.List<DetectionsHighestTotalBucket> highestTotalBuckets) {
+            this.highestTotalBuckets = highestTotalBuckets;
+            return this;
+        }
+
 
         public DetectionsSummary build() {
-            return new DetectionsSummary(total, buckets);
+            return new DetectionsSummary(total, buckets, highestTotalBuckets);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/DeviceHighestTotalBucket.java
+++ b/java/src/main/java/io/worlds/api/model/DeviceHighestTotalBucket.java
@@ -1,0 +1,104 @@
+package io.worlds.api.model;
+
+import java.util.Objects;
+
+/**
+ * A bucket selected as having the greatest `total` within its group, returned from
+[`DeviceSummary.highestTotalBuckets`]({{Types.DeviceSummary}}).
+ */
+public class DeviceHighestTotalBucket implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @jakarta.validation.constraints.NotNull
+    private DeviceSummaryBucketKey key;
+    private int total;
+
+    public DeviceHighestTotalBucket() {
+    }
+
+    public DeviceHighestTotalBucket(DeviceSummaryBucketKey key, int total) {
+        this.key = key;
+        this.total = total;
+    }
+
+    /**
+     * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+     */
+    public DeviceSummaryBucketKey getKey() {
+        return key;
+    }
+    /**
+     * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+     */
+    public void setKey(DeviceSummaryBucketKey key) {
+        this.key = key;
+    }
+
+    /**
+     * The total number of devices in the winning bucket.
+     */
+    public int getTotal() {
+        return total;
+    }
+    /**
+     * The total number of devices in the winning bucket.
+     */
+    public void setTotal(int total) {
+        this.total = total;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final DeviceHighestTotalBucket that = (DeviceHighestTotalBucket) obj;
+        return Objects.equals(key, that.key)
+            && Objects.equals(total, that.total);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, total);
+    }
+
+
+    public static DeviceHighestTotalBucket.Builder builder() {
+        return new DeviceHighestTotalBucket.Builder();
+    }
+
+    public static class Builder {
+
+        private DeviceSummaryBucketKey key;
+        private int total;
+
+        public Builder() {
+        }
+
+        /**
+         * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+         */
+        public Builder setKey(DeviceSummaryBucketKey key) {
+            this.key = key;
+            return this;
+        }
+
+        /**
+         * The total number of devices in the winning bucket.
+         */
+        public Builder setTotal(int total) {
+            this.total = total;
+            return this;
+        }
+
+
+        public DeviceHighestTotalBucket build() {
+            return new DeviceHighestTotalBucket(key, total);
+        }
+
+    }
+}

--- a/java/src/main/java/io/worlds/api/model/DeviceSummary.java
+++ b/java/src/main/java/io/worlds/api/model/DeviceSummary.java
@@ -11,13 +11,16 @@ public class DeviceSummary implements java.io.Serializable {
 
     private int total;
     private java.util.List<DeviceSummaryBucket> buckets;
+    @jakarta.validation.constraints.NotNull
+    private java.util.List<DeviceHighestTotalBucket> highestTotalBuckets;
 
     public DeviceSummary() {
     }
 
-    public DeviceSummary(int total, java.util.List<DeviceSummaryBucket> buckets) {
+    public DeviceSummary(int total, java.util.List<DeviceSummaryBucket> buckets, java.util.List<DeviceHighestTotalBucket> highestTotalBuckets) {
         this.total = total;
         this.buckets = buckets;
+        this.highestTotalBuckets = highestTotalBuckets;
     }
 
     /**
@@ -48,6 +51,21 @@ Summary buckets are only returned if `deviceBucket` is provided as a query param
         this.buckets = buckets;
     }
 
+    /**
+     * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `deviceBucket`
+was provided.  All tied buckets are returned per group.
+     */
+    public java.util.List<DeviceHighestTotalBucket> getHighestTotalBuckets() {
+        return highestTotalBuckets;
+    }
+    /**
+     * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `deviceBucket`
+was provided.  All tied buckets are returned per group.
+     */
+    public void setHighestTotalBuckets(java.util.List<DeviceHighestTotalBucket> highestTotalBuckets) {
+        this.highestTotalBuckets = highestTotalBuckets;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -58,12 +76,13 @@ Summary buckets are only returned if `deviceBucket` is provided as a query param
         }
         final DeviceSummary that = (DeviceSummary) obj;
         return Objects.equals(total, that.total)
-            && Objects.equals(buckets, that.buckets);
+            && Objects.equals(buckets, that.buckets)
+            && Objects.equals(highestTotalBuckets, that.highestTotalBuckets);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(total, buckets);
+        return Objects.hash(total, buckets, highestTotalBuckets);
     }
 
 
@@ -75,6 +94,7 @@ Summary buckets are only returned if `deviceBucket` is provided as a query param
 
         private int total;
         private java.util.List<DeviceSummaryBucket> buckets;
+        private java.util.List<DeviceHighestTotalBucket> highestTotalBuckets;
 
         public Builder() {
         }
@@ -96,9 +116,18 @@ Summary buckets are only returned if `deviceBucket` is provided as a query param
             return this;
         }
 
+        /**
+         * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `deviceBucket`
+was provided.  All tied buckets are returned per group.
+         */
+        public Builder setHighestTotalBuckets(java.util.List<DeviceHighestTotalBucket> highestTotalBuckets) {
+            this.highestTotalBuckets = highestTotalBuckets;
+            return this;
+        }
+
 
         public DeviceSummary build() {
-            return new DeviceSummary(total, buckets);
+            return new DeviceSummary(total, buckets, highestTotalBuckets);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/EventsHighestTotalBucket.java
+++ b/java/src/main/java/io/worlds/api/model/EventsHighestTotalBucket.java
@@ -1,0 +1,104 @@
+package io.worlds.api.model;
+
+import java.util.Objects;
+
+/**
+ * A bucket selected as having the greatest `total` within its group, returned from
+[`EventsSummary.highestTotalBuckets`]({{Types.EventsSummary}}).
+ */
+public class EventsHighestTotalBucket implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @jakarta.validation.constraints.NotNull
+    private EventsSummaryBucketKey key;
+    private int total;
+
+    public EventsHighestTotalBucket() {
+    }
+
+    public EventsHighestTotalBucket(EventsSummaryBucketKey key, int total) {
+        this.key = key;
+        this.total = total;
+    }
+
+    /**
+     * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+     */
+    public EventsSummaryBucketKey getKey() {
+        return key;
+    }
+    /**
+     * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+     */
+    public void setKey(EventsSummaryBucketKey key) {
+        this.key = key;
+    }
+
+    /**
+     * The total number of [Events]({{Types.Event}}) in the winning bucket.
+     */
+    public int getTotal() {
+        return total;
+    }
+    /**
+     * The total number of [Events]({{Types.Event}}) in the winning bucket.
+     */
+    public void setTotal(int total) {
+        this.total = total;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final EventsHighestTotalBucket that = (EventsHighestTotalBucket) obj;
+        return Objects.equals(key, that.key)
+            && Objects.equals(total, that.total);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, total);
+    }
+
+
+    public static EventsHighestTotalBucket.Builder builder() {
+        return new EventsHighestTotalBucket.Builder();
+    }
+
+    public static class Builder {
+
+        private EventsSummaryBucketKey key;
+        private int total;
+
+        public Builder() {
+        }
+
+        /**
+         * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+         */
+        public Builder setKey(EventsSummaryBucketKey key) {
+            this.key = key;
+            return this;
+        }
+
+        /**
+         * The total number of [Events]({{Types.Event}}) in the winning bucket.
+         */
+        public Builder setTotal(int total) {
+            this.total = total;
+            return this;
+        }
+
+
+        public EventsHighestTotalBucket build() {
+            return new EventsHighestTotalBucket(key, total);
+        }
+
+    }
+}

--- a/java/src/main/java/io/worlds/api/model/EventsSummary.java
+++ b/java/src/main/java/io/worlds/api/model/EventsSummary.java
@@ -86,14 +86,14 @@ public class EventsSummary implements java.io.Serializable {
 
     /**
      * A detailed summary of each [bucket]({{Types.SummaryBucketSize}}) within the time range.
-Summary buckets are only returned if `bucket` is provided as a query parameter to [`eventsSummary`]({{Queries.eventsSummary}}).
+Summary buckets are only returned if `eventsBucket` is provided as a query parameter to [`eventsSummary`]({{Queries.eventsSummary}}).
      */
     public java.util.List<EventsSummaryBucket> getBuckets() {
         return buckets;
     }
     /**
      * A detailed summary of each [bucket]({{Types.SummaryBucketSize}}) within the time range.
-Summary buckets are only returned if `bucket` is provided as a query parameter to [`eventsSummary`]({{Queries.eventsSummary}}).
+Summary buckets are only returned if `eventsBucket` is provided as a query parameter to [`eventsSummary`]({{Queries.eventsSummary}}).
      */
     public void setBuckets(java.util.List<EventsSummaryBucket> buckets) {
         this.buckets = buckets;
@@ -204,7 +204,7 @@ Useful for discovering available metadata keys that can be used for metadata buc
 
         /**
          * A detailed summary of each [bucket]({{Types.SummaryBucketSize}}) within the time range.
-Summary buckets are only returned if `bucket` is provided as a query parameter to [`eventsSummary`]({{Queries.eventsSummary}}).
+Summary buckets are only returned if `eventsBucket` is provided as a query parameter to [`eventsSummary`]({{Queries.eventsSummary}}).
          */
         public Builder setBuckets(java.util.List<EventsSummaryBucket> buckets) {
             this.buckets = buckets;

--- a/java/src/main/java/io/worlds/api/model/EventsSummary.java
+++ b/java/src/main/java/io/worlds/api/model/EventsSummary.java
@@ -15,17 +15,20 @@ public class EventsSummary implements java.io.Serializable {
     @jakarta.validation.constraints.NotNull
     private EventsSummaryStatistics summaryStatistics;
     private java.util.List<EventsSummaryBucket> buckets;
+    @jakarta.validation.constraints.NotNull
+    private java.util.List<EventsHighestTotalBucket> highestTotalBuckets;
     private java.util.List<String> metadataKeys;
 
     public EventsSummary() {
     }
 
-    public EventsSummary(int total, int startedCount, int endedCount, EventsSummaryStatistics summaryStatistics, java.util.List<EventsSummaryBucket> buckets, java.util.List<String> metadataKeys) {
+    public EventsSummary(int total, int startedCount, int endedCount, EventsSummaryStatistics summaryStatistics, java.util.List<EventsSummaryBucket> buckets, java.util.List<EventsHighestTotalBucket> highestTotalBuckets, java.util.List<String> metadataKeys) {
         this.total = total;
         this.startedCount = startedCount;
         this.endedCount = endedCount;
         this.summaryStatistics = summaryStatistics;
         this.buckets = buckets;
+        this.highestTotalBuckets = highestTotalBuckets;
         this.metadataKeys = metadataKeys;
     }
 
@@ -97,6 +100,21 @@ Summary buckets are only returned if `bucket` is provided as a query parameter t
     }
 
     /**
+     * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `eventsBucket`
+was provided.  All tied buckets are returned per group.
+     */
+    public java.util.List<EventsHighestTotalBucket> getHighestTotalBuckets() {
+        return highestTotalBuckets;
+    }
+    /**
+     * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `eventsBucket`
+was provided.  All tied buckets are returned per group.
+     */
+    public void setHighestTotalBuckets(java.util.List<EventsHighestTotalBucket> highestTotalBuckets) {
+        this.highestTotalBuckets = highestTotalBuckets;
+    }
+
+    /**
      * The distinct top-level keys found in the `metadata` field across all matching events.
 Useful for discovering available metadata keys that can be used for metadata bucketing.
      */
@@ -125,12 +143,13 @@ Useful for discovering available metadata keys that can be used for metadata buc
             && Objects.equals(endedCount, that.endedCount)
             && Objects.equals(summaryStatistics, that.summaryStatistics)
             && Objects.equals(buckets, that.buckets)
+            && Objects.equals(highestTotalBuckets, that.highestTotalBuckets)
             && Objects.equals(metadataKeys, that.metadataKeys);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(total, startedCount, endedCount, summaryStatistics, buckets, metadataKeys);
+        return Objects.hash(total, startedCount, endedCount, summaryStatistics, buckets, highestTotalBuckets, metadataKeys);
     }
 
 
@@ -145,6 +164,7 @@ Useful for discovering available metadata keys that can be used for metadata buc
         private int endedCount;
         private EventsSummaryStatistics summaryStatistics;
         private java.util.List<EventsSummaryBucket> buckets;
+        private java.util.List<EventsHighestTotalBucket> highestTotalBuckets;
         private java.util.List<String> metadataKeys;
 
         public Builder() {
@@ -192,6 +212,15 @@ Summary buckets are only returned if `bucket` is provided as a query parameter t
         }
 
         /**
+         * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `eventsBucket`
+was provided.  All tied buckets are returned per group.
+         */
+        public Builder setHighestTotalBuckets(java.util.List<EventsHighestTotalBucket> highestTotalBuckets) {
+            this.highestTotalBuckets = highestTotalBuckets;
+            return this;
+        }
+
+        /**
          * The distinct top-level keys found in the `metadata` field across all matching events.
 Useful for discovering available metadata keys that can be used for metadata bucketing.
          */
@@ -202,7 +231,7 @@ Useful for discovering available metadata keys that can be used for metadata buc
 
 
         public EventsSummary build() {
-            return new EventsSummary(total, startedCount, endedCount, summaryStatistics, buckets, metadataKeys);
+            return new EventsSummary(total, startedCount, endedCount, summaryStatistics, buckets, highestTotalBuckets, metadataKeys);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/TracksHighestTotalBucket.java
+++ b/java/src/main/java/io/worlds/api/model/TracksHighestTotalBucket.java
@@ -1,0 +1,104 @@
+package io.worlds.api.model;
+
+import java.util.Objects;
+
+/**
+ * A bucket selected as having the greatest `total` within its group, returned from
+[`TracksSummary.highestTotalBuckets`]({{Types.TracksSummary}}).
+ */
+public class TracksHighestTotalBucket implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @jakarta.validation.constraints.NotNull
+    private TracksSummaryBucketKey key;
+    private int total;
+
+    public TracksHighestTotalBucket() {
+    }
+
+    public TracksHighestTotalBucket(TracksSummaryBucketKey key, int total) {
+        this.key = key;
+        this.total = total;
+    }
+
+    /**
+     * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+     */
+    public TracksSummaryBucketKey getKey() {
+        return key;
+    }
+    /**
+     * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+     */
+    public void setKey(TracksSummaryBucketKey key) {
+        this.key = key;
+    }
+
+    /**
+     * The total number of [Tracks]({{Types.Track}}) in the winning bucket.
+     */
+    public int getTotal() {
+        return total;
+    }
+    /**
+     * The total number of [Tracks]({{Types.Track}}) in the winning bucket.
+     */
+    public void setTotal(int total) {
+        this.total = total;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final TracksHighestTotalBucket that = (TracksHighestTotalBucket) obj;
+        return Objects.equals(key, that.key)
+            && Objects.equals(total, that.total);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, total);
+    }
+
+
+    public static TracksHighestTotalBucket.Builder builder() {
+        return new TracksHighestTotalBucket.Builder();
+    }
+
+    public static class Builder {
+
+        private TracksSummaryBucketKey key;
+        private int total;
+
+        public Builder() {
+        }
+
+        /**
+         * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+         */
+        public Builder setKey(TracksSummaryBucketKey key) {
+            this.key = key;
+            return this;
+        }
+
+        /**
+         * The total number of [Tracks]({{Types.Track}}) in the winning bucket.
+         */
+        public Builder setTotal(int total) {
+            this.total = total;
+            return this;
+        }
+
+
+        public TracksHighestTotalBucket build() {
+            return new TracksHighestTotalBucket(key, total);
+        }
+
+    }
+}

--- a/java/src/main/java/io/worlds/api/model/TracksSummary.java
+++ b/java/src/main/java/io/worlds/api/model/TracksSummary.java
@@ -84,14 +84,14 @@ public class TracksSummary implements java.io.Serializable {
 
     /**
      * A detailed summary of each [bucket]({{Types.SummaryBucketSize}}) within the time range.
-Summary buckets are only returned if `bucket` is provided as a query parameter to [`tracksSummary`]({{Queries.tracksSummary}}).
+Summary buckets are only returned if `tracksBucket` is provided as a query parameter to [`tracksSummary`]({{Queries.tracksSummary}}).
      */
     public java.util.List<TracksSummaryBucket> getBuckets() {
         return buckets;
     }
     /**
      * A detailed summary of each [bucket]({{Types.SummaryBucketSize}}) within the time range.
-Summary buckets are only returned if `bucket` is provided as a query parameter to [`tracksSummary`]({{Queries.tracksSummary}}).
+Summary buckets are only returned if `tracksBucket` is provided as a query parameter to [`tracksSummary`]({{Queries.tracksSummary}}).
      */
     public void setBuckets(java.util.List<TracksSummaryBucket> buckets) {
         this.buckets = buckets;
@@ -186,7 +186,7 @@ was provided.  All tied buckets are returned per group.
 
         /**
          * A detailed summary of each [bucket]({{Types.SummaryBucketSize}}) within the time range.
-Summary buckets are only returned if `bucket` is provided as a query parameter to [`tracksSummary`]({{Queries.tracksSummary}}).
+Summary buckets are only returned if `tracksBucket` is provided as a query parameter to [`tracksSummary`]({{Queries.tracksSummary}}).
          */
         public Builder setBuckets(java.util.List<TracksSummaryBucket> buckets) {
             this.buckets = buckets;

--- a/java/src/main/java/io/worlds/api/model/TracksSummary.java
+++ b/java/src/main/java/io/worlds/api/model/TracksSummary.java
@@ -13,16 +13,19 @@ public class TracksSummary implements java.io.Serializable {
     @jakarta.validation.constraints.NotNull
     private java.util.List<TracksCountByTag> totalsByTag;
     private java.util.List<TracksSummaryBucket> buckets;
+    @jakarta.validation.constraints.NotNull
+    private java.util.List<TracksHighestTotalBucket> highestTotalBuckets;
 
     public TracksSummary() {
     }
 
-    public TracksSummary(int total, int startedCount, int endedCount, java.util.List<TracksCountByTag> totalsByTag, java.util.List<TracksSummaryBucket> buckets) {
+    public TracksSummary(int total, int startedCount, int endedCount, java.util.List<TracksCountByTag> totalsByTag, java.util.List<TracksSummaryBucket> buckets, java.util.List<TracksHighestTotalBucket> highestTotalBuckets) {
         this.total = total;
         this.startedCount = startedCount;
         this.endedCount = endedCount;
         this.totalsByTag = totalsByTag;
         this.buckets = buckets;
+        this.highestTotalBuckets = highestTotalBuckets;
     }
 
     /**
@@ -94,6 +97,21 @@ Summary buckets are only returned if `bucket` is provided as a query parameter t
         this.buckets = buckets;
     }
 
+    /**
+     * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `tracksBucket`
+was provided.  All tied buckets are returned per group.
+     */
+    public java.util.List<TracksHighestTotalBucket> getHighestTotalBuckets() {
+        return highestTotalBuckets;
+    }
+    /**
+     * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `tracksBucket`
+was provided.  All tied buckets are returned per group.
+     */
+    public void setHighestTotalBuckets(java.util.List<TracksHighestTotalBucket> highestTotalBuckets) {
+        this.highestTotalBuckets = highestTotalBuckets;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -107,12 +125,13 @@ Summary buckets are only returned if `bucket` is provided as a query parameter t
             && Objects.equals(startedCount, that.startedCount)
             && Objects.equals(endedCount, that.endedCount)
             && Objects.equals(totalsByTag, that.totalsByTag)
-            && Objects.equals(buckets, that.buckets);
+            && Objects.equals(buckets, that.buckets)
+            && Objects.equals(highestTotalBuckets, that.highestTotalBuckets);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(total, startedCount, endedCount, totalsByTag, buckets);
+        return Objects.hash(total, startedCount, endedCount, totalsByTag, buckets, highestTotalBuckets);
     }
 
 
@@ -127,6 +146,7 @@ Summary buckets are only returned if `bucket` is provided as a query parameter t
         private int endedCount;
         private java.util.List<TracksCountByTag> totalsByTag;
         private java.util.List<TracksSummaryBucket> buckets;
+        private java.util.List<TracksHighestTotalBucket> highestTotalBuckets;
 
         public Builder() {
         }
@@ -173,9 +193,18 @@ Summary buckets are only returned if `bucket` is provided as a query parameter t
             return this;
         }
 
+        /**
+         * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `tracksBucket`
+was provided.  All tied buckets are returned per group.
+         */
+        public Builder setHighestTotalBuckets(java.util.List<TracksHighestTotalBucket> highestTotalBuckets) {
+            this.highestTotalBuckets = highestTotalBuckets;
+            return this;
+        }
+
 
         public TracksSummary build() {
-            return new TracksSummary(total, startedCount, endedCount, totalsByTag, buckets);
+            return new TracksSummary(total, startedCount, endedCount, totalsByTag, buckets, highestTotalBuckets);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/TracksSummaryBucketKey.java
+++ b/java/src/main/java/io/worlds/api/model/TracksSummaryBucketKey.java
@@ -13,12 +13,12 @@ public class TracksSummaryBucketKey implements java.io.Serializable {
     private Tag tag;
     private DataSource dataSource;
     private Site dataSourceSite;
-    private Site dataSourcePointOfInterest;
+    private PointOfInterest dataSourcePointOfInterest;
 
     public TracksSummaryBucketKey() {
     }
 
-    public TracksSummaryBucketKey(java.time.OffsetDateTime time, Tag tag, DataSource dataSource, Site dataSourceSite, Site dataSourcePointOfInterest) {
+    public TracksSummaryBucketKey(java.time.OffsetDateTime time, Tag tag, DataSource dataSource, Site dataSourceSite, PointOfInterest dataSourcePointOfInterest) {
         this.time = time;
         this.tag = tag;
         this.dataSource = dataSource;
@@ -81,13 +81,13 @@ public class TracksSummaryBucketKey implements java.io.Serializable {
     /**
      * The point of interest for data sources which produced the tracks.
      */
-    public Site getDataSourcePointOfInterest() {
+    public PointOfInterest getDataSourcePointOfInterest() {
         return dataSourcePointOfInterest;
     }
     /**
      * The point of interest for data sources which produced the tracks.
      */
-    public void setDataSourcePointOfInterest(Site dataSourcePointOfInterest) {
+    public void setDataSourcePointOfInterest(PointOfInterest dataSourcePointOfInterest) {
         this.dataSourcePointOfInterest = dataSourcePointOfInterest;
     }
 
@@ -123,7 +123,7 @@ public class TracksSummaryBucketKey implements java.io.Serializable {
         private Tag tag;
         private DataSource dataSource;
         private Site dataSourceSite;
-        private Site dataSourcePointOfInterest;
+        private PointOfInterest dataSourcePointOfInterest;
 
         public Builder() {
         }
@@ -163,7 +163,7 @@ public class TracksSummaryBucketKey implements java.io.Serializable {
         /**
          * The point of interest for data sources which produced the tracks.
          */
-        public Builder setDataSourcePointOfInterest(Site dataSourcePointOfInterest) {
+        public Builder setDataSourcePointOfInterest(PointOfInterest dataSourcePointOfInterest) {
             this.dataSourcePointOfInterest = dataSourcePointOfInterest;
             return this;
         }

--- a/java/src/main/java/io/worlds/api/model/VideosHighestTotalBucket.java
+++ b/java/src/main/java/io/worlds/api/model/VideosHighestTotalBucket.java
@@ -1,0 +1,104 @@
+package io.worlds.api.model;
+
+import java.util.Objects;
+
+/**
+ * A bucket selected as having the greatest `total` within its group, returned from
+[`VideosSummary.highestTotalBuckets`]({{Types.VideosSummary}}).
+ */
+public class VideosHighestTotalBucket implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @jakarta.validation.constraints.NotNull
+    private VideosSummaryBucketKey key;
+    private int total;
+
+    public VideosHighestTotalBucket() {
+    }
+
+    public VideosHighestTotalBucket(VideosSummaryBucketKey key, int total) {
+        this.key = key;
+        this.total = total;
+    }
+
+    /**
+     * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+     */
+    public VideosSummaryBucketKey getKey() {
+        return key;
+    }
+    /**
+     * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+     */
+    public void setKey(VideosSummaryBucketKey key) {
+        this.key = key;
+    }
+
+    /**
+     * The total number of [Videos]({{Types.Video}}) in the winning bucket.
+     */
+    public int getTotal() {
+        return total;
+    }
+    /**
+     * The total number of [Videos]({{Types.Video}}) in the winning bucket.
+     */
+    public void setTotal(int total) {
+        this.total = total;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final VideosHighestTotalBucket that = (VideosHighestTotalBucket) obj;
+        return Objects.equals(key, that.key)
+            && Objects.equals(total, that.total);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, total);
+    }
+
+
+    public static VideosHighestTotalBucket.Builder builder() {
+        return new VideosHighestTotalBucket.Builder();
+    }
+
+    public static class Builder {
+
+        private VideosSummaryBucketKey key;
+        private int total;
+
+        public Builder() {
+        }
+
+        /**
+         * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+         */
+        public Builder setKey(VideosSummaryBucketKey key) {
+            this.key = key;
+            return this;
+        }
+
+        /**
+         * The total number of [Videos]({{Types.Video}}) in the winning bucket.
+         */
+        public Builder setTotal(int total) {
+            this.total = total;
+            return this;
+        }
+
+
+        public VideosHighestTotalBucket build() {
+            return new VideosHighestTotalBucket(key, total);
+        }
+
+    }
+}

--- a/java/src/main/java/io/worlds/api/model/VideosSummary.java
+++ b/java/src/main/java/io/worlds/api/model/VideosSummary.java
@@ -15,16 +15,19 @@ public class VideosSummary implements java.io.Serializable {
     @jakarta.validation.constraints.NotNull
     private VideosSummaryStatistics summaryStatistics;
     private java.util.List<VideosSummaryBucket> buckets;
+    @jakarta.validation.constraints.NotNull
+    private java.util.List<VideosHighestTotalBucket> highestTotalBuckets;
 
     public VideosSummary() {
     }
 
-    public VideosSummary(int total, int startedCount, int endedCount, VideosSummaryStatistics summaryStatistics, java.util.List<VideosSummaryBucket> buckets) {
+    public VideosSummary(int total, int startedCount, int endedCount, VideosSummaryStatistics summaryStatistics, java.util.List<VideosSummaryBucket> buckets, java.util.List<VideosHighestTotalBucket> highestTotalBuckets) {
         this.total = total;
         this.startedCount = startedCount;
         this.endedCount = endedCount;
         this.summaryStatistics = summaryStatistics;
         this.buckets = buckets;
+        this.highestTotalBuckets = highestTotalBuckets;
     }
 
     /**
@@ -94,6 +97,21 @@ Summary buckets are only returned if `bucket` is provided as a query parameter t
         this.buckets = buckets;
     }
 
+    /**
+     * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `videosBucket`
+was provided.  All tied buckets are returned per group.
+     */
+    public java.util.List<VideosHighestTotalBucket> getHighestTotalBuckets() {
+        return highestTotalBuckets;
+    }
+    /**
+     * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `videosBucket`
+was provided.  All tied buckets are returned per group.
+     */
+    public void setHighestTotalBuckets(java.util.List<VideosHighestTotalBucket> highestTotalBuckets) {
+        this.highestTotalBuckets = highestTotalBuckets;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -107,12 +125,13 @@ Summary buckets are only returned if `bucket` is provided as a query parameter t
             && Objects.equals(startedCount, that.startedCount)
             && Objects.equals(endedCount, that.endedCount)
             && Objects.equals(summaryStatistics, that.summaryStatistics)
-            && Objects.equals(buckets, that.buckets);
+            && Objects.equals(buckets, that.buckets)
+            && Objects.equals(highestTotalBuckets, that.highestTotalBuckets);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(total, startedCount, endedCount, summaryStatistics, buckets);
+        return Objects.hash(total, startedCount, endedCount, summaryStatistics, buckets, highestTotalBuckets);
     }
 
 
@@ -127,6 +146,7 @@ Summary buckets are only returned if `bucket` is provided as a query parameter t
         private int endedCount;
         private VideosSummaryStatistics summaryStatistics;
         private java.util.List<VideosSummaryBucket> buckets;
+        private java.util.List<VideosHighestTotalBucket> highestTotalBuckets;
 
         public Builder() {
         }
@@ -172,9 +192,18 @@ Summary buckets are only returned if `bucket` is provided as a query parameter t
             return this;
         }
 
+        /**
+         * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `videosBucket`
+was provided.  All tied buckets are returned per group.
+         */
+        public Builder setHighestTotalBuckets(java.util.List<VideosHighestTotalBucket> highestTotalBuckets) {
+            this.highestTotalBuckets = highestTotalBuckets;
+            return this;
+        }
+
 
         public VideosSummary build() {
-            return new VideosSummary(total, startedCount, endedCount, summaryStatistics, buckets);
+            return new VideosSummary(total, startedCount, endedCount, summaryStatistics, buckets, highestTotalBuckets);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/VideosSummary.java
+++ b/java/src/main/java/io/worlds/api/model/VideosSummary.java
@@ -84,14 +84,14 @@ public class VideosSummary implements java.io.Serializable {
 
     /**
      * A detailed summary of each [bucket]({{Types.SummaryBucketSize}}) within the time range.
-Summary buckets are only returned if `bucket` is provided as a query parameter to [`videosSummary`]({{Queries.videosSummary}}).
+Summary buckets are only returned if `videosBucket` is provided as a query parameter to [`videosSummary`]({{Queries.videosSummary}}).
      */
     public java.util.List<VideosSummaryBucket> getBuckets() {
         return buckets;
     }
     /**
      * A detailed summary of each [bucket]({{Types.SummaryBucketSize}}) within the time range.
-Summary buckets are only returned if `bucket` is provided as a query parameter to [`videosSummary`]({{Queries.videosSummary}}).
+Summary buckets are only returned if `videosBucket` is provided as a query parameter to [`videosSummary`]({{Queries.videosSummary}}).
      */
     public void setBuckets(java.util.List<VideosSummaryBucket> buckets) {
         this.buckets = buckets;
@@ -185,7 +185,7 @@ was provided.  All tied buckets are returned per group.
 
         /**
          * A detailed summary of each [bucket]({{Types.SummaryBucketSize}}) within the time range.
-Summary buckets are only returned if `bucket` is provided as a query parameter to [`videosSummary`]({{Queries.videosSummary}}).
+Summary buckets are only returned if `videosBucket` is provided as a query parameter to [`videosSummary`]({{Queries.videosSummary}}).
          */
         public Builder setBuckets(java.util.List<VideosSummaryBucket> buckets) {
             this.buckets = buckets;

--- a/java/src/main/java/io/worlds/api/model/ZoneIntersectionHighestTotalBucket.java
+++ b/java/src/main/java/io/worlds/api/model/ZoneIntersectionHighestTotalBucket.java
@@ -1,0 +1,104 @@
+package io.worlds.api.model;
+
+import java.util.Objects;
+
+/**
+ * A bucket selected as having the greatest `total` within its group, returned from
+[`ZoneIntersectionSummary.highestTotalBuckets`]({{Types.ZoneIntersectionSummary}}).
+ */
+public class ZoneIntersectionHighestTotalBucket implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @jakarta.validation.constraints.NotNull
+    private ZoneIntersectionSummaryBucketKey key;
+    private int total;
+
+    public ZoneIntersectionHighestTotalBucket() {
+    }
+
+    public ZoneIntersectionHighestTotalBucket(ZoneIntersectionSummaryBucketKey key, int total) {
+        this.key = key;
+        this.total = total;
+    }
+
+    /**
+     * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+     */
+    public ZoneIntersectionSummaryBucketKey getKey() {
+        return key;
+    }
+    /**
+     * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+     */
+    public void setKey(ZoneIntersectionSummaryBucketKey key) {
+        this.key = key;
+    }
+
+    /**
+     * The total number of zone intersections in the winning bucket.
+     */
+    public int getTotal() {
+        return total;
+    }
+    /**
+     * The total number of zone intersections in the winning bucket.
+     */
+    public void setTotal(int total) {
+        this.total = total;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final ZoneIntersectionHighestTotalBucket that = (ZoneIntersectionHighestTotalBucket) obj;
+        return Objects.equals(key, that.key)
+            && Objects.equals(total, that.total);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, total);
+    }
+
+
+    public static ZoneIntersectionHighestTotalBucket.Builder builder() {
+        return new ZoneIntersectionHighestTotalBucket.Builder();
+    }
+
+    public static class Builder {
+
+        private ZoneIntersectionSummaryBucketKey key;
+        private int total;
+
+        public Builder() {
+        }
+
+        /**
+         * The key of the winning bucket.  Only fields included in `groupBy` are populated; others are null.
+         */
+        public Builder setKey(ZoneIntersectionSummaryBucketKey key) {
+            this.key = key;
+            return this;
+        }
+
+        /**
+         * The total number of zone intersections in the winning bucket.
+         */
+        public Builder setTotal(int total) {
+            this.total = total;
+            return this;
+        }
+
+
+        public ZoneIntersectionHighestTotalBucket build() {
+            return new ZoneIntersectionHighestTotalBucket(key, total);
+        }
+
+    }
+}

--- a/java/src/main/java/io/worlds/api/model/ZoneIntersectionSummary.java
+++ b/java/src/main/java/io/worlds/api/model/ZoneIntersectionSummary.java
@@ -15,16 +15,19 @@ public class ZoneIntersectionSummary implements java.io.Serializable {
     @jakarta.validation.constraints.NotNull
     private ZoneIntersectionSummaryStatistics summaryStatistics;
     private java.util.List<ZoneIntersectionSummaryBucket> buckets;
+    @jakarta.validation.constraints.NotNull
+    private java.util.List<ZoneIntersectionHighestTotalBucket> highestTotalBuckets;
 
     public ZoneIntersectionSummary() {
     }
 
-    public ZoneIntersectionSummary(int total, int startedCount, int endedCount, ZoneIntersectionSummaryStatistics summaryStatistics, java.util.List<ZoneIntersectionSummaryBucket> buckets) {
+    public ZoneIntersectionSummary(int total, int startedCount, int endedCount, ZoneIntersectionSummaryStatistics summaryStatistics, java.util.List<ZoneIntersectionSummaryBucket> buckets, java.util.List<ZoneIntersectionHighestTotalBucket> highestTotalBuckets) {
         this.total = total;
         this.startedCount = startedCount;
         this.endedCount = endedCount;
         this.summaryStatistics = summaryStatistics;
         this.buckets = buckets;
+        this.highestTotalBuckets = highestTotalBuckets;
     }
 
     /**
@@ -94,6 +97,21 @@ Summary buckets are only returned if `zoneIntersectionBucket` is provided as a q
         this.buckets = buckets;
     }
 
+    /**
+     * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `zoneIntersectionBucket`
+was provided.  All tied buckets are returned per group.
+     */
+    public java.util.List<ZoneIntersectionHighestTotalBucket> getHighestTotalBuckets() {
+        return highestTotalBuckets;
+    }
+    /**
+     * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `zoneIntersectionBucket`
+was provided.  All tied buckets are returned per group.
+     */
+    public void setHighestTotalBuckets(java.util.List<ZoneIntersectionHighestTotalBucket> highestTotalBuckets) {
+        this.highestTotalBuckets = highestTotalBuckets;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -107,12 +125,13 @@ Summary buckets are only returned if `zoneIntersectionBucket` is provided as a q
             && Objects.equals(startedCount, that.startedCount)
             && Objects.equals(endedCount, that.endedCount)
             && Objects.equals(summaryStatistics, that.summaryStatistics)
-            && Objects.equals(buckets, that.buckets);
+            && Objects.equals(buckets, that.buckets)
+            && Objects.equals(highestTotalBuckets, that.highestTotalBuckets);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(total, startedCount, endedCount, summaryStatistics, buckets);
+        return Objects.hash(total, startedCount, endedCount, summaryStatistics, buckets, highestTotalBuckets);
     }
 
 
@@ -127,6 +146,7 @@ Summary buckets are only returned if `zoneIntersectionBucket` is provided as a q
         private int endedCount;
         private ZoneIntersectionSummaryStatistics summaryStatistics;
         private java.util.List<ZoneIntersectionSummaryBucket> buckets;
+        private java.util.List<ZoneIntersectionHighestTotalBucket> highestTotalBuckets;
 
         public Builder() {
         }
@@ -172,9 +192,18 @@ Summary buckets are only returned if `zoneIntersectionBucket` is provided as a q
             return this;
         }
 
+        /**
+         * The bucket(s) with the greatest `total` across the parent's buckets.  Empty if no `zoneIntersectionBucket`
+was provided.  All tied buckets are returned per group.
+         */
+        public Builder setHighestTotalBuckets(java.util.List<ZoneIntersectionHighestTotalBucket> highestTotalBuckets) {
+            this.highestTotalBuckets = highestTotalBuckets;
+            return this;
+        }
+
 
         public ZoneIntersectionSummary build() {
-            return new ZoneIntersectionSummary(total, startedCount, endedCount, summaryStatistics, buckets);
+            return new ZoneIntersectionSummary(total, startedCount, endedCount, summaryStatistics, buckets, highestTotalBuckets);
         }
 
     }


### PR DESCRIPTION
## Summary
- Add `highestTotalBuckets` field and corresponding `HighestTotalBucket` types to the remaining summary types (`Events`, `Videos`, `ActivityChronicle`, `ZoneIntersection`, `Detections`, `Device`), matching the pattern already added for `Tracks`.
- Each field returns the bucket(s) with the greatest `total` per group, with an optional `groupBy` argument to keep dimensions distinct when finding the max.

## Test plan
- [ ] Schema compiles / generated client builds
- [ ] Query `highestTotalBuckets` on each summary type and verify the winning bucket(s) and ties are returned

[CE-8301]

[CE-8301]: https://worlds-io.atlassian.net/browse/CE-8301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ