### PR TITLE
feat: REQ-1033: Add transcoderId to Device and device mutations

### DIFF
--- a/graphql/api/domains/devices/device.graphqls
+++ b/graphql/api/domains/devices/device.graphqls
@@ -22,6 +22,8 @@ type Device {
     dataSource: DataSource
     """The site that this device belongs to"""
     site: Site
+    """The unique identifier of the transcoder associated with this device."""
+    transcoderId: ID
     """The list of calibrations for the device"""
     calibrations: [DeviceCalibration!]!
     """The point of interest the device belongs to"""
@@ -76,6 +78,8 @@ input CreateDeviceInput {
     siteId: ID
     """The unique identifier for the point of interest the device belongs to."""
     pointOfInterestId: ID
+    """The unique identifier of the transcoder associated with this device."""
+    transcoderId: ID
     """An identifier that the device may use outside of Worlds."""
     externalId: ID
     """The name of the device."""
@@ -98,6 +102,8 @@ input UpdateDeviceInput {
     siteId: ID
     """The unique identifier for the point of interest the device belongs to."""
     pointOfInterestId: ID
+    """The unique identifier of the transcoder associated with this device."""
+    transcoderId: ID
     """An identifier that the device may use outside of Worlds."""
     externalId: ID
     """The name of the device."""

--- a/java/src/main/java/io/worlds/api/model/CreateDeviceInput.java
+++ b/java/src/main/java/io/worlds/api/model/CreateDeviceInput.java
@@ -11,6 +11,7 @@ public class CreateDeviceInput implements java.io.Serializable {
 
     private org.springframework.graphql.data.ArgumentValue<String> siteId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<String> pointOfInterestId = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<String> transcoderId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<String> externalId = org.springframework.graphql.data.ArgumentValue.omitted();
     @jakarta.validation.constraints.NotNull
     private String name;
@@ -21,9 +22,10 @@ public class CreateDeviceInput implements java.io.Serializable {
     public CreateDeviceInput() {
     }
 
-    public CreateDeviceInput(org.springframework.graphql.data.ArgumentValue<String> siteId, org.springframework.graphql.data.ArgumentValue<String> pointOfInterestId, org.springframework.graphql.data.ArgumentValue<String> externalId, String name, org.springframework.graphql.data.ArgumentValue<String> address, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, boolean enabled) {
+    public CreateDeviceInput(org.springframework.graphql.data.ArgumentValue<String> siteId, org.springframework.graphql.data.ArgumentValue<String> pointOfInterestId, org.springframework.graphql.data.ArgumentValue<String> transcoderId, org.springframework.graphql.data.ArgumentValue<String> externalId, String name, org.springframework.graphql.data.ArgumentValue<String> address, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, boolean enabled) {
         this.siteId = siteId;
         this.pointOfInterestId = pointOfInterestId;
+        this.transcoderId = transcoderId;
         this.externalId = externalId;
         this.name = name;
         this.address = address;
@@ -43,6 +45,13 @@ public class CreateDeviceInput implements java.io.Serializable {
     }
     public void setPointOfInterestId(org.springframework.graphql.data.ArgumentValue<String> pointOfInterestId) {
         this.pointOfInterestId = pointOfInterestId;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<String> getTranscoderId() {
+        return transcoderId;
+    }
+    public void setTranscoderId(org.springframework.graphql.data.ArgumentValue<String> transcoderId) {
+        this.transcoderId = transcoderId;
     }
 
     public org.springframework.graphql.data.ArgumentValue<String> getExternalId() {
@@ -91,6 +100,7 @@ public class CreateDeviceInput implements java.io.Serializable {
         final CreateDeviceInput that = (CreateDeviceInput) obj;
         return Objects.equals(siteId, that.siteId)
             && Objects.equals(pointOfInterestId, that.pointOfInterestId)
+            && Objects.equals(transcoderId, that.transcoderId)
             && Objects.equals(externalId, that.externalId)
             && Objects.equals(name, that.name)
             && Objects.equals(address, that.address)
@@ -100,7 +110,7 @@ public class CreateDeviceInput implements java.io.Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(siteId, pointOfInterestId, externalId, name, address, position, enabled);
+        return Objects.hash(siteId, pointOfInterestId, transcoderId, externalId, name, address, position, enabled);
     }
 
 
@@ -112,6 +122,7 @@ public class CreateDeviceInput implements java.io.Serializable {
 
         private org.springframework.graphql.data.ArgumentValue<String> siteId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<String> pointOfInterestId = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<String> transcoderId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<String> externalId = org.springframework.graphql.data.ArgumentValue.omitted();
         private String name;
         private org.springframework.graphql.data.ArgumentValue<String> address = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -128,6 +139,11 @@ public class CreateDeviceInput implements java.io.Serializable {
 
         public Builder setPointOfInterestId(org.springframework.graphql.data.ArgumentValue<String> pointOfInterestId) {
             this.pointOfInterestId = pointOfInterestId;
+            return this;
+        }
+
+        public Builder setTranscoderId(org.springframework.graphql.data.ArgumentValue<String> transcoderId) {
+            this.transcoderId = transcoderId;
             return this;
         }
 
@@ -158,7 +174,7 @@ public class CreateDeviceInput implements java.io.Serializable {
 
 
         public CreateDeviceInput build() {
-            return new CreateDeviceInput(siteId, pointOfInterestId, externalId, name, address, position, enabled);
+            return new CreateDeviceInput(siteId, pointOfInterestId, transcoderId, externalId, name, address, position, enabled);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/Device.java
+++ b/java/src/main/java/io/worlds/api/model/Device.java
@@ -22,6 +22,7 @@ public class Device implements java.io.Serializable {
     private GeoJSONPoint position;
     private DataSource dataSource;
     private Site site;
+    private String transcoderId;
     @jakarta.validation.constraints.NotNull
     private java.util.List<DeviceCalibration> calibrations;
     private PointOfInterest pointOfInterest;
@@ -30,7 +31,7 @@ public class Device implements java.io.Serializable {
     public Device() {
     }
 
-    public Device(String id, String uuid, String externalId, String name, boolean enabled, String address, Double frameRate, GeoJSONPoint position, DataSource dataSource, Site site, java.util.List<DeviceCalibration> calibrations, PointOfInterest pointOfInterest, java.time.OffsetDateTime lastHeartbeat) {
+    public Device(String id, String uuid, String externalId, String name, boolean enabled, String address, Double frameRate, GeoJSONPoint position, DataSource dataSource, Site site, String transcoderId, java.util.List<DeviceCalibration> calibrations, PointOfInterest pointOfInterest, java.time.OffsetDateTime lastHeartbeat) {
         this.id = id;
         this.uuid = uuid;
         this.externalId = externalId;
@@ -41,6 +42,7 @@ public class Device implements java.io.Serializable {
         this.position = position;
         this.dataSource = dataSource;
         this.site = site;
+        this.transcoderId = transcoderId;
         this.calibrations = calibrations;
         this.pointOfInterest = pointOfInterest;
         this.lastHeartbeat = lastHeartbeat;
@@ -177,6 +179,19 @@ public class Device implements java.io.Serializable {
     }
 
     /**
+     * The unique identifier of the transcoder associated with this device.
+     */
+    public String getTranscoderId() {
+        return transcoderId;
+    }
+    /**
+     * The unique identifier of the transcoder associated with this device.
+     */
+    public void setTranscoderId(String transcoderId) {
+        this.transcoderId = transcoderId;
+    }
+
+    /**
      * The list of calibrations for the device
      */
     public java.util.List<DeviceCalibration> getCalibrations() {
@@ -234,6 +249,7 @@ public class Device implements java.io.Serializable {
             && Objects.equals(position, that.position)
             && Objects.equals(dataSource, that.dataSource)
             && Objects.equals(site, that.site)
+            && Objects.equals(transcoderId, that.transcoderId)
             && Objects.equals(calibrations, that.calibrations)
             && Objects.equals(pointOfInterest, that.pointOfInterest)
             && Objects.equals(lastHeartbeat, that.lastHeartbeat);
@@ -241,7 +257,7 @@ public class Device implements java.io.Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, uuid, externalId, name, enabled, address, frameRate, position, dataSource, site, calibrations, pointOfInterest, lastHeartbeat);
+        return Objects.hash(id, uuid, externalId, name, enabled, address, frameRate, position, dataSource, site, transcoderId, calibrations, pointOfInterest, lastHeartbeat);
     }
 
 
@@ -261,6 +277,7 @@ public class Device implements java.io.Serializable {
         private GeoJSONPoint position;
         private DataSource dataSource;
         private Site site;
+        private String transcoderId;
         private java.util.List<DeviceCalibration> calibrations;
         private PointOfInterest pointOfInterest;
         private java.time.OffsetDateTime lastHeartbeat;
@@ -349,6 +366,14 @@ public class Device implements java.io.Serializable {
         }
 
         /**
+         * The unique identifier of the transcoder associated with this device.
+         */
+        public Builder setTranscoderId(String transcoderId) {
+            this.transcoderId = transcoderId;
+            return this;
+        }
+
+        /**
          * The list of calibrations for the device
          */
         public Builder setCalibrations(java.util.List<DeviceCalibration> calibrations) {
@@ -374,7 +399,7 @@ public class Device implements java.io.Serializable {
 
 
         public Device build() {
-            return new Device(id, uuid, externalId, name, enabled, address, frameRate, position, dataSource, site, calibrations, pointOfInterest, lastHeartbeat);
+            return new Device(id, uuid, externalId, name, enabled, address, frameRate, position, dataSource, site, transcoderId, calibrations, pointOfInterest, lastHeartbeat);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/UpdateDeviceInput.java
+++ b/java/src/main/java/io/worlds/api/model/UpdateDeviceInput.java
@@ -13,6 +13,7 @@ public class UpdateDeviceInput implements java.io.Serializable {
     private String id;
     private org.springframework.graphql.data.ArgumentValue<String> siteId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<String> pointOfInterestId = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<String> transcoderId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<String> externalId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<String> name = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<String> address = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -22,10 +23,11 @@ public class UpdateDeviceInput implements java.io.Serializable {
     public UpdateDeviceInput() {
     }
 
-    public UpdateDeviceInput(String id, org.springframework.graphql.data.ArgumentValue<String> siteId, org.springframework.graphql.data.ArgumentValue<String> pointOfInterestId, org.springframework.graphql.data.ArgumentValue<String> externalId, org.springframework.graphql.data.ArgumentValue<String> name, org.springframework.graphql.data.ArgumentValue<String> address, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, org.springframework.graphql.data.ArgumentValue<Boolean> enabled) {
+    public UpdateDeviceInput(String id, org.springframework.graphql.data.ArgumentValue<String> siteId, org.springframework.graphql.data.ArgumentValue<String> pointOfInterestId, org.springframework.graphql.data.ArgumentValue<String> transcoderId, org.springframework.graphql.data.ArgumentValue<String> externalId, org.springframework.graphql.data.ArgumentValue<String> name, org.springframework.graphql.data.ArgumentValue<String> address, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, org.springframework.graphql.data.ArgumentValue<Boolean> enabled) {
         this.id = id;
         this.siteId = siteId;
         this.pointOfInterestId = pointOfInterestId;
+        this.transcoderId = transcoderId;
         this.externalId = externalId;
         this.name = name;
         this.address = address;
@@ -52,6 +54,13 @@ public class UpdateDeviceInput implements java.io.Serializable {
     }
     public void setPointOfInterestId(org.springframework.graphql.data.ArgumentValue<String> pointOfInterestId) {
         this.pointOfInterestId = pointOfInterestId;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<String> getTranscoderId() {
+        return transcoderId;
+    }
+    public void setTranscoderId(org.springframework.graphql.data.ArgumentValue<String> transcoderId) {
+        this.transcoderId = transcoderId;
     }
 
     public org.springframework.graphql.data.ArgumentValue<String> getExternalId() {
@@ -101,6 +110,7 @@ public class UpdateDeviceInput implements java.io.Serializable {
         return Objects.equals(id, that.id)
             && Objects.equals(siteId, that.siteId)
             && Objects.equals(pointOfInterestId, that.pointOfInterestId)
+            && Objects.equals(transcoderId, that.transcoderId)
             && Objects.equals(externalId, that.externalId)
             && Objects.equals(name, that.name)
             && Objects.equals(address, that.address)
@@ -110,7 +120,7 @@ public class UpdateDeviceInput implements java.io.Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, siteId, pointOfInterestId, externalId, name, address, position, enabled);
+        return Objects.hash(id, siteId, pointOfInterestId, transcoderId, externalId, name, address, position, enabled);
     }
 
 
@@ -123,6 +133,7 @@ public class UpdateDeviceInput implements java.io.Serializable {
         private String id;
         private org.springframework.graphql.data.ArgumentValue<String> siteId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<String> pointOfInterestId = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<String> transcoderId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<String> externalId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<String> name = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<String> address = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -144,6 +155,11 @@ public class UpdateDeviceInput implements java.io.Serializable {
 
         public Builder setPointOfInterestId(org.springframework.graphql.data.ArgumentValue<String> pointOfInterestId) {
             this.pointOfInterestId = pointOfInterestId;
+            return this;
+        }
+
+        public Builder setTranscoderId(org.springframework.graphql.data.ArgumentValue<String> transcoderId) {
+            this.transcoderId = transcoderId;
             return this;
         }
 
@@ -174,7 +190,7 @@ public class UpdateDeviceInput implements java.io.Serializable {
 
 
         public UpdateDeviceInput build() {
-            return new UpdateDeviceInput(id, siteId, pointOfInterestId, externalId, name, address, position, enabled);
+            return new UpdateDeviceInput(id, siteId, pointOfInterestId, transcoderId, externalId, name, address, position, enabled);
         }
 
     }


### PR DESCRIPTION
## Summary
- Add a nullable `transcoderId` ID field to the `Device` type for associating a camera with a transcoder.
- Add `transcoderId` to the `CreateDeviceInput` and `UpdateDeviceInput` mutation inputs.
- Regenerate the Java SDK model classes from the updated schema.

## Test plan
- [x] `mvn generate-sources` produces `transcoderId` getters/setters on `Device`, `CreateDeviceInput`, `UpdateDeviceInput`.
- [x] `mvn install` builds and publishes the SNAPSHOT successfully.

[REQ-1033]

[REQ-1033]: https://worlds-io.atlassian.net/browse/REQ-1033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ