### PR TITLE
feat: CE-9975: Add delete mutations to chronicle domains

### DIFF
--- a/graphql/api/domains/chronicle/activity/mutation.graphqls
+++ b/graphql/api/domains/chronicle/activity/mutation.graphqls
@@ -1,17 +1,17 @@
 extend type Mutation {
     """
-    Creates a new [Event Chronicle]({{Types.EventChronicle}}). This allows for the creation of custom events within the Worlds system.
+    Creates a new activity chronicle.
     """
     createActivityChronicle(
-        """Arguments to create a new event chronicle."""
+        """Arguments to create a new activity chronicle."""
         activityChronicle: CreateActivityChronicleInput!
     ): ActivityChronicle!
-    """Updates an existing [Event Chronicle]({{Types.EventChronicle}})."""
+    """Updates an existing activity chronicle."""
     updateActivityChronicle(
-        """Arguments to update an existing event chronicle."""
+        """Arguments to update an existing activity chronicle."""
         activityChronicle: UpdateActivityChronicleInput!
     ): ActivityChronicle!
-    """Deletes an existing [Activity Chronicle]({{Types.ActivityChronicle}})."""
+    """Deletes an existing activity chronicle."""
     deleteActivityChronicle(
         """The unique identifier of the activity chronicle to delete."""
         id: ID!

--- a/graphql/api/domains/chronicle/activity/mutation.graphqls
+++ b/graphql/api/domains/chronicle/activity/mutation.graphqls
@@ -11,4 +11,9 @@ extend type Mutation {
         """Arguments to update an existing event chronicle."""
         activityChronicle: UpdateActivityChronicleInput!
     ): ActivityChronicle!
+    """Deletes an existing [Activity Chronicle]({{Types.ActivityChronicle}})."""
+    deleteActivityChronicle(
+        """The unique identifier of the activity chronicle to delete."""
+        id: ID!
+    ): ActivityChronicle
 }

--- a/graphql/api/domains/chronicle/event/mutation.graphqls
+++ b/graphql/api/domains/chronicle/event/mutation.graphqls
@@ -11,4 +11,9 @@ extend type Mutation {
         """Arguments to update an existing event chronicle."""
         eventChronicle: UpdateEventChronicleInput!
     ): EventChronicle!
+    """Deletes an existing [Event Chronicle]({{Types.EventChronicle}})."""
+    deleteEventChronicle(
+        """The unique identifier of the event chronicle to delete."""
+        id: ID!
+    ): EventChronicle
 }

--- a/graphql/api/domains/chronicle/event/mutation.graphqls
+++ b/graphql/api/domains/chronicle/event/mutation.graphqls
@@ -1,17 +1,17 @@
 extend type Mutation {
     """
-    Creates a new [Event Chronicle]({{Types.EventChronicle}}). This allows for the creation of custom events within the Worlds system.
+    Creates a new event chronicle.
     """
     createEventChronicle(
         """Arguments to create a new event chronicle."""
         eventChronicle: CreateEventChronicleInput!
     ): EventChronicle!
-    """Updates an existing [Event Chronicle]({{Types.EventChronicle}})."""
+    """Updates an existing event chronicle."""
     updateEventChronicle(
         """Arguments to update an existing event chronicle."""
         eventChronicle: UpdateEventChronicleInput!
     ): EventChronicle!
-    """Deletes an existing [Event Chronicle]({{Types.EventChronicle}})."""
+    """Deletes an existing event chronicle."""
     deleteEventChronicle(
         """The unique identifier of the event chronicle to delete."""
         id: ID!

--- a/graphql/api/domains/chronicle/mutation.graphqls
+++ b/graphql/api/domains/chronicle/mutation.graphqls
@@ -11,4 +11,9 @@ extend type Mutation {
         """Arguments to update an existing chronicle producer."""
         chronicleProducer: UpdateChronicleProducerInput!
     ): ChronicleProducer!
+    """Deletes an existing ChronicleProducer."""
+    deleteChronicleProducer(
+        """The unique identifier of the chronicle producer to delete."""
+        id: ID!
+    ): ChronicleProducer
 }

--- a/graphql/api/domains/chronicle/summary/mutation.graphqls
+++ b/graphql/api/domains/chronicle/summary/mutation.graphqls
@@ -1,17 +1,17 @@
 extend type Mutation {
     """
-    Creates a new [Summary Chronicle]({{Types.SummaryChronicle}}). This allows for the creation of custom summaries within the Worlds system.
+    Creates a new summary chronicle.
     """
     createSummaryChronicle(
         """Arguments to create a new summary chronicle."""
         summaryChronicle: CreateSummaryChronicleInput!
     ): SummaryChronicle!
-    """Updates an existing [Summary Chronicle]({{Types.SummaryChronicle}})."""
+    """Updates an existing summary chronicle."""
     updateSummaryChronicle(
         """Arguments to update an existing summary chronicle."""
         summaryChronicle: UpdateSummaryChronicleInput!
     ): SummaryChronicle!
-    """Deletes an existing [Summary Chronicle]({{Types.SummaryChronicle}})."""
+    """Deletes an existing summary chronicle."""
     deleteSummaryChronicle(
         """The unique identifier of the summary chronicle to delete."""
         id: ID!

--- a/graphql/api/domains/chronicle/summary/mutation.graphqls
+++ b/graphql/api/domains/chronicle/summary/mutation.graphqls
@@ -11,4 +11,9 @@ extend type Mutation {
         """Arguments to update an existing summary chronicle."""
         summaryChronicle: UpdateSummaryChronicleInput!
     ): SummaryChronicle!
+    """Deletes an existing [Summary Chronicle]({{Types.SummaryChronicle}})."""
+    deleteSummaryChronicle(
+        """The unique identifier of the summary chronicle to delete."""
+        id: ID!
+    ): SummaryChronicle
 }


### PR DESCRIPTION
## Summary
- Add `deleteChronicleProducer`, `deleteActivityChronicle`, `deleteEventChronicle`, and `deleteSummaryChronicle` mutations.
- Follows the existing `deleteZone` pattern (takes `id: ID!`, returns the nullable type).

And clean up nearby docstrings.

## Test plan
- [x] `mvn generate-sources` succeeds and generates the mutation classes.

[CE-9975]

[CE-9975]: https://worlds-io.atlassian.net/browse/CE-9975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ