### PR TITLE
feat: CE-9976: Add delete mutations to dataSource and device domains

### DIFF
--- a/graphql/api/domains/dataSource/mutation.graphqls
+++ b/graphql/api/domains/dataSource/mutation.graphqls
@@ -9,4 +9,9 @@ extend type Mutation {
         """Arguments to update an existing data source."""
         dataSource: UpdateDataSourceInput!
     ): DataSource
+    """Deletes an existing DataSource."""
+    deleteDataSource(
+        """The unique identifier of the data source to delete."""
+        id: ID!
+    ): DataSource
 }

--- a/graphql/api/domains/devices/mutation.graphqls
+++ b/graphql/api/domains/devices/mutation.graphqls
@@ -9,4 +9,9 @@ extend type Mutation {
         """Arguments to update an existing device."""
         device: UpdateDeviceInput!
     ): Device
+    """Deletes an existing Device."""
+    deleteDevice(
+        """The unique identifier of the device to delete."""
+        id: ID!
+    ): Device
 }


### PR DESCRIPTION
## Summary
- Add `deleteDataSource(id: ID!)` mutation to the dataSource domain.
- Add `deleteDevice(id: ID!)` mutation to the device domain.
- Both follow the existing `deleteZone` pattern, returning the deleted entity.

## Test plan
- [ ] `mvn generate-sources` regenerates Java classes cleanly.
- [ ] Schema validates and new mutations appear in the generated API.

[CE-9976]

[CE-9976]: https://worlds-io.atlassian.net/browse/CE-9976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ