### PR TITLE
feat: CE-9977: Add delete mutations to site and pointOfInterest domains

### DIFF
--- a/graphql/api/domains/pointOfInterest/mutation.graphqls
+++ b/graphql/api/domains/pointOfInterest/mutation.graphqls
@@ -11,4 +11,9 @@ extend type Mutation {
         """Arguments to update an existing point of interest."""
         pointOfInterest: UpdatePointOfInterestInput!
     ): PointOfInterest
+    """Deletes an existing PointOfInterest."""
+    deletePointOfInterest(
+        """The unique identifier of the point of interest to delete."""
+        id: ID!
+    ): PointOfInterest
 }

--- a/graphql/api/domains/site/mutation.graphqls
+++ b/graphql/api/domains/site/mutation.graphqls
@@ -11,4 +11,9 @@ extend type Mutation {
         """Arguments to update an existing site."""
         site: UpdateSiteInput!
     ): Site
+    """Deletes an existing Site."""
+    deleteSite(
+        """The unique identifier of the site to delete."""
+        id: ID!
+    ): Site
 }


### PR DESCRIPTION
## Summary
- Add `deleteSite(id: ID!)` mutation to the site domain.
- Add `deletePointOfInterest(id: ID!)` mutation to the pointOfInterest domain.
- Both follow the existing `deleteZone` pattern, returning the deleted entity.

## Test plan
- [ ] `mvn generate-sources` regenerates Java classes cleanly.
- [ ] Schema validates and new mutations appear in the generated API.

[CE-9977]

[CE-9977]: https://worlds-io.atlassian.net/browse/CE-9977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ