### PR TITLE
feat: CE-9975: Add deleteActivityChronicles bulk mutation

### DIFF
--- a/graphql/api/domains/chronicle/activity/mutation.graphqls
+++ b/graphql/api/domains/chronicle/activity/mutation.graphqls
@@ -16,4 +16,9 @@ extend type Mutation {
         """The unique identifier of the activity chronicle to delete."""
         id: ID!
     ): ActivityChronicle
+    """Deletes existing activity chronicles."""
+    deleteActivityChronicles(
+        """The unique identifiers of the activity chronicles to delete."""
+        id: [ID]!
+    ): [ActivityChronicle]
 }


### PR DESCRIPTION
## Summary
- Add `deleteActivityChronicles` mutation accepting a list of IDs to delete multiple activity chronicles in one call, complementing the existing single-delete mutation.

## Test plan
- [x] Validate the schema compiles and the mutation appears in the generated GraphQL API.

[CE-9975]

[CE-9975]: https://worlds-io.atlassian.net/browse/CE-9975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ