### PR TITLE
feat: CE-11014: Add deleteGeofence mutation

### DIFF
--- a/graphql/api/domains/geofence/mutation.graphqls
+++ b/graphql/api/domains/geofence/mutation.graphqls
@@ -11,4 +11,9 @@ extend type Mutation {
         """Arguments to update an existing geofence."""
         geofence: UpdateGeofenceInput!
     ): Geofence
+    """Deletes an existing Geofence."""
+    deleteGeofence(
+        """The unique identifier of the geofence to delete."""
+        id: ID!
+    ): Geofence
 }


### PR DESCRIPTION
## Summary
- Add a `deleteGeofence(id: ID!)` mutation to the geofence GraphQL schema, completing CRUD parity with the existing site and pointOfInterest delete mutations.

## Test plan
- [x] Schema validates / builds successfully
- [x] `deleteGeofence` mutation appears in the generated API and deletes a geofence by ID

[CE-11014]

[CE-11014]: https://worlds-io.atlassian.net/browse/CE-11014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ