### PR TITLE
feat: CE-11611: Add siteId filter to track query and subscription

### DIFF
--- a/graphql/api/domains/track/filter.graphqls
+++ b/graphql/api/domains/track/filter.graphqls
@@ -36,6 +36,10 @@ input FilterTrackInput {
     """
     pointOfInterestId: FilterIDInput
     """
+    If provided, specifies filters that work against the [unique identifier of the site]({{Types.Site}}) that the track's data source belongs to.
+    """
+    siteId: FilterIDInput
+    """
     If provided, specifies filters that work against the `type` of the track's [`dataSource`]({{Types.DataSource}}).
     """
     dataSourceType: FilterStringInput
@@ -94,6 +98,10 @@ input FilterTrackMessageInput {
     If provided, specifies filters that work against the [unique identifier of the point of interest]({{Types.Site}}) of the track's data source.
     """
     pointOfInterestId: FilterIDInput
+    """
+    If provided, specifies filters that work against the [unique identifier of the site]({{Types.Site}}) that the track's data source belongs to.
+    """
+    siteId: FilterIDInput
     """
     If provided, specifies filters that work against the `type` of the track's [`dataSource`]({{Types.DataSource}}).
     """

--- a/java/src/main/java/io/worlds/api/model/FilterTrackInput.java
+++ b/java/src/main/java/io/worlds/api/model/FilterTrackInput.java
@@ -19,6 +19,7 @@ public class FilterTrackInput implements java.io.Serializable {
     private org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels = org.springframework.graphql.data.ArgumentValue.omitted();
     private java.util.List<FilterTrackInput> and;
@@ -30,7 +31,7 @@ public class FilterTrackInput implements java.io.Serializable {
     public FilterTrackInput() {
     }
 
-    public FilterTrackInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId, FilterDateTimeOffsetInput time, org.springframework.graphql.data.ArgumentValue<FilterStringInput> tag, org.springframework.graphql.data.ArgumentValue<FilterPointInput> position, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute, org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels, java.util.List<FilterTrackInput> and, java.util.List<FilterTrackInput> or, org.springframework.graphql.data.ArgumentValue<FilterTrackInput> not, org.springframework.graphql.data.ArgumentValue<FilterIDInput> deviceId) {
+    public FilterTrackInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId, FilterDateTimeOffsetInput time, org.springframework.graphql.data.ArgumentValue<FilterStringInput> tag, org.springframework.graphql.data.ArgumentValue<FilterPointInput> position, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute, org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId, org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels, java.util.List<FilterTrackInput> and, java.util.List<FilterTrackInput> or, org.springframework.graphql.data.ArgumentValue<FilterTrackInput> not, org.springframework.graphql.data.ArgumentValue<FilterIDInput> deviceId) {
         this.id = id;
         this.dataSourceId = dataSourceId;
         this.time = time;
@@ -39,6 +40,7 @@ public class FilterTrackInput implements java.io.Serializable {
         this.identifier = identifier;
         this.attribute = attribute;
         this.pointOfInterestId = pointOfInterestId;
+        this.siteId = siteId;
         this.dataSourceType = dataSourceType;
         this.dataSourceLabels = dataSourceLabels;
         this.and = and;
@@ -103,6 +105,13 @@ public class FilterTrackInput implements java.io.Serializable {
         this.pointOfInterestId = pointOfInterestId;
     }
 
+    public org.springframework.graphql.data.ArgumentValue<FilterIDInput> getSiteId() {
+        return siteId;
+    }
+    public void setSiteId(org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId) {
+        this.siteId = siteId;
+    }
+
     public org.springframework.graphql.data.ArgumentValue<FilterStringInput> getDataSourceType() {
         return dataSourceType;
     }
@@ -164,6 +173,7 @@ public class FilterTrackInput implements java.io.Serializable {
             && Objects.equals(identifier, that.identifier)
             && Objects.equals(attribute, that.attribute)
             && Objects.equals(pointOfInterestId, that.pointOfInterestId)
+            && Objects.equals(siteId, that.siteId)
             && Objects.equals(dataSourceType, that.dataSourceType)
             && Objects.equals(dataSourceLabels, that.dataSourceLabels)
             && Objects.equals(and, that.and)
@@ -174,7 +184,7 @@ public class FilterTrackInput implements java.io.Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, dataSourceId, time, tag, position, identifier, attribute, pointOfInterestId, dataSourceType, dataSourceLabels, and, or, not, deviceId);
+        return Objects.hash(id, dataSourceId, time, tag, position, identifier, attribute, pointOfInterestId, siteId, dataSourceType, dataSourceLabels, and, or, not, deviceId);
     }
 
 
@@ -192,6 +202,7 @@ public class FilterTrackInput implements java.io.Serializable {
         private org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels = org.springframework.graphql.data.ArgumentValue.omitted();
         private java.util.List<FilterTrackInput> and;
@@ -242,6 +253,11 @@ public class FilterTrackInput implements java.io.Serializable {
             return this;
         }
 
+        public Builder setSiteId(org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId) {
+            this.siteId = siteId;
+            return this;
+        }
+
         public Builder setDataSourceType(org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType) {
             this.dataSourceType = dataSourceType;
             return this;
@@ -275,7 +291,7 @@ public class FilterTrackInput implements java.io.Serializable {
 
 
         public FilterTrackInput build() {
-            return new FilterTrackInput(id, dataSourceId, time, tag, position, identifier, attribute, pointOfInterestId, dataSourceType, dataSourceLabels, and, or, not, deviceId);
+            return new FilterTrackInput(id, dataSourceId, time, tag, position, identifier, attribute, pointOfInterestId, siteId, dataSourceType, dataSourceLabels, and, or, not, deviceId);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/FilterTrackMessageInput.java
+++ b/java/src/main/java/io/worlds/api/model/FilterTrackMessageInput.java
@@ -17,6 +17,7 @@ public class FilterTrackMessageInput implements java.io.Serializable {
     private org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterMessageStateInput> state = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -27,7 +28,7 @@ public class FilterTrackMessageInput implements java.io.Serializable {
     public FilterTrackMessageInput() {
     }
 
-    public FilterTrackMessageInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> tag, org.springframework.graphql.data.ArgumentValue<FilterPointInput> position, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute, org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels, org.springframework.graphql.data.ArgumentValue<FilterMessageStateInput> state, java.util.List<FilterTrackMessageInput> and, java.util.List<FilterTrackMessageInput> or, org.springframework.graphql.data.ArgumentValue<FilterTrackMessageInput> not) {
+    public FilterTrackMessageInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> tag, org.springframework.graphql.data.ArgumentValue<FilterPointInput> position, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute, org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId, org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels, org.springframework.graphql.data.ArgumentValue<FilterMessageStateInput> state, java.util.List<FilterTrackMessageInput> and, java.util.List<FilterTrackMessageInput> or, org.springframework.graphql.data.ArgumentValue<FilterTrackMessageInput> not) {
         this.id = id;
         this.dataSourceId = dataSourceId;
         this.tag = tag;
@@ -35,6 +36,7 @@ public class FilterTrackMessageInput implements java.io.Serializable {
         this.identifier = identifier;
         this.attribute = attribute;
         this.pointOfInterestId = pointOfInterestId;
+        this.siteId = siteId;
         this.dataSourceType = dataSourceType;
         this.dataSourceLabels = dataSourceLabels;
         this.state = state;
@@ -90,6 +92,13 @@ public class FilterTrackMessageInput implements java.io.Serializable {
     }
     public void setPointOfInterestId(org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId) {
         this.pointOfInterestId = pointOfInterestId;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<FilterIDInput> getSiteId() {
+        return siteId;
+    }
+    public void setSiteId(org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId) {
+        this.siteId = siteId;
     }
 
     public org.springframework.graphql.data.ArgumentValue<FilterStringInput> getDataSourceType() {
@@ -150,6 +159,7 @@ public class FilterTrackMessageInput implements java.io.Serializable {
             && Objects.equals(identifier, that.identifier)
             && Objects.equals(attribute, that.attribute)
             && Objects.equals(pointOfInterestId, that.pointOfInterestId)
+            && Objects.equals(siteId, that.siteId)
             && Objects.equals(dataSourceType, that.dataSourceType)
             && Objects.equals(dataSourceLabels, that.dataSourceLabels)
             && Objects.equals(state, that.state)
@@ -160,7 +170,7 @@ public class FilterTrackMessageInput implements java.io.Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, dataSourceId, tag, position, identifier, attribute, pointOfInterestId, dataSourceType, dataSourceLabels, state, and, or, not);
+        return Objects.hash(id, dataSourceId, tag, position, identifier, attribute, pointOfInterestId, siteId, dataSourceType, dataSourceLabels, state, and, or, not);
     }
 
 
@@ -177,6 +187,7 @@ public class FilterTrackMessageInput implements java.io.Serializable {
         private org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterMessageStateInput> state = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -222,6 +233,11 @@ public class FilterTrackMessageInput implements java.io.Serializable {
             return this;
         }
 
+        public Builder setSiteId(org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId) {
+            this.siteId = siteId;
+            return this;
+        }
+
         public Builder setDataSourceType(org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType) {
             this.dataSourceType = dataSourceType;
             return this;
@@ -254,7 +270,7 @@ public class FilterTrackMessageInput implements java.io.Serializable {
 
 
         public FilterTrackMessageInput build() {
-            return new FilterTrackMessageInput(id, dataSourceId, tag, position, identifier, attribute, pointOfInterestId, dataSourceType, dataSourceLabels, state, and, or, not);
+            return new FilterTrackMessageInput(id, dataSourceId, tag, position, identifier, attribute, pointOfInterestId, siteId, dataSourceType, dataSourceLabels, state, and, or, not);
         }
 
     }


### PR DESCRIPTION
## Summary
- Add `siteId: FilterIDInput` to `FilterTrackInput` (tracks query) and `FilterTrackMessageInput` (tracks subscription) so track requests can be scoped to a single site.
- Enables Overwatch to load only tracks belonging to the active site, reducing track volume and payload for multi-site environments.
- Regenerated Java SDK models to reflect the new field.

## Test plan
- [x] `mvn generate-sources` regenerates `FilterTrackInput`/`FilterTrackMessageInput` with `siteId` getters/setters/builders
- [x] `mvn install` builds the SNAPSHOT successfully
- [x] tracks-service wires `siteId` into the track query + subscription resolvers (follow-up)

[CE-11611]

[CE-11611]: https://worlds-io.atlassian.net/browse/CE-11611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ