### PR TITLE
REQ-715: Make position required for site

### DIFF
--- a/graphql/api/domains/site/site.graphqls
+++ b/graphql/api/domains/site/site.graphqls
@@ -9,7 +9,7 @@ type Site {
     """The IANA timezone identifier for this site (e.g. 'America/New_York', 'UTC')."""
     timezone: String!
     """The geographic location of the site"""
-    position: GeoJSONPoint
+    position: GeoJSONPoint!
     """The geographic shape of the site"""
     polygon: GeoJSONMultiPolygon
     """The devices that are associated with the site"""
@@ -29,7 +29,7 @@ input CreateSiteInput {
     """The IANA timezone identifier for this site (e.g. 'America/New_York'). Defaults to 'UTC' if not provided."""
     timezone: String
     """The geographic location of the site"""
-    position: GeoJSONPointInput
+    position: GeoJSONPointInput!
     """The geographic shape of the site"""
     polygon: GeoJSONMultiPolygonInput
 }

--- a/java/src/main/java/io/worlds/api/model/CreateSiteInput.java
+++ b/java/src/main/java/io/worlds/api/model/CreateSiteInput.java
@@ -12,13 +12,14 @@ public class CreateSiteInput implements java.io.Serializable {
     @jakarta.validation.constraints.NotNull
     private String name;
     private org.springframework.graphql.data.ArgumentValue<String> timezone = org.springframework.graphql.data.ArgumentValue.omitted();
-    private org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position = org.springframework.graphql.data.ArgumentValue.omitted();
+    @jakarta.validation.constraints.NotNull
+    private GeoJSONPointInput position;
     private org.springframework.graphql.data.ArgumentValue<GeoJSONMultiPolygonInput> polygon = org.springframework.graphql.data.ArgumentValue.omitted();
 
     public CreateSiteInput() {
     }
 
-    public CreateSiteInput(String name, org.springframework.graphql.data.ArgumentValue<String> timezone, org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position, org.springframework.graphql.data.ArgumentValue<GeoJSONMultiPolygonInput> polygon) {
+    public CreateSiteInput(String name, org.springframework.graphql.data.ArgumentValue<String> timezone, GeoJSONPointInput position, org.springframework.graphql.data.ArgumentValue<GeoJSONMultiPolygonInput> polygon) {
         this.name = name;
         this.timezone = timezone;
         this.position = position;
@@ -39,10 +40,10 @@ public class CreateSiteInput implements java.io.Serializable {
         this.timezone = timezone;
     }
 
-    public org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> getPosition() {
+    public GeoJSONPointInput getPosition() {
         return position;
     }
-    public void setPosition(org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position) {
+    public void setPosition(GeoJSONPointInput position) {
         this.position = position;
     }
 
@@ -82,7 +83,7 @@ public class CreateSiteInput implements java.io.Serializable {
 
         private String name;
         private org.springframework.graphql.data.ArgumentValue<String> timezone = org.springframework.graphql.data.ArgumentValue.omitted();
-        private org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position = org.springframework.graphql.data.ArgumentValue.omitted();
+        private GeoJSONPointInput position;
         private org.springframework.graphql.data.ArgumentValue<GeoJSONMultiPolygonInput> polygon = org.springframework.graphql.data.ArgumentValue.omitted();
 
         public Builder() {
@@ -98,7 +99,7 @@ public class CreateSiteInput implements java.io.Serializable {
             return this;
         }
 
-        public Builder setPosition(org.springframework.graphql.data.ArgumentValue<GeoJSONPointInput> position) {
+        public Builder setPosition(GeoJSONPointInput position) {
             this.position = position;
             return this;
         }

--- a/java/src/main/java/io/worlds/api/model/Site.java
+++ b/java/src/main/java/io/worlds/api/model/Site.java
@@ -15,6 +15,7 @@ public class Site implements java.io.Serializable, UnifiedSearchNameResponseEnti
     private String name;
     @jakarta.validation.constraints.NotNull
     private String timezone;
+    @jakarta.validation.constraints.NotNull
     private GeoJSONPoint position;
     private GeoJSONMultiPolygon polygon;
     @jakarta.validation.constraints.NotNull


### PR DESCRIPTION
## Description of Changes
Make `site.location` required on both the domain type and the create mutation.  While making location required on the mutation is a breaking change, all creations without a site would fail in practice due to a missing foreign key.

## Link to Related Jira Ticket
[REQ-715]

[REQ-715]: https://worlds-io.atlassian.net/browse/REQ-715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ