### PR TITLE
feat: CE-11399: Add TimeRangeInput and FilterTimeRangeInput

### DIFF
--- a/graphql/api/domains/chronicle/activity/filter.graphqls
+++ b/graphql/api/domains/chronicle/activity/filter.graphqls
@@ -24,6 +24,12 @@ input FilterActivityChronicleInput {
     """
     endTime: FilterDateTimeOffsetInput
     """
+    If provided, specifies filters that work against the period the [`ActivityChronicle`]({{Types.ActivityChronicle}})
+    spans, from its `startTime` to its `endTime`. An activity that has not ended is treated as running until
+    the end of time.
+    """
+    timeRange: FilterTimeRangeInput
+    """
     If provided, specifies filters that work against the `timezone` of the [`ActivityChronicle`]({{Types.ActivityChronicle}}).
     """
     timezone: FilterStringInput

--- a/graphql/api/domains/track/filter.graphqls
+++ b/graphql/api/domains/track/filter.graphqls
@@ -14,7 +14,13 @@ input FilterTrackInput {
     """
     If provided, specifies filters that work against the [time]({{Types.Track}}) associated with the start time of a track.
     """
-    time: FilterDateTimeOffsetInput!
+    time: FilterDateTimeOffsetInput
+    """
+    If provided, specifies filters that work against the period a track spans, from its
+    [`startTime`]({{Types.Track}}) to its [`endTime`]({{Types.Track}}). A track that is still being tracked
+    has no end time and is treated as running until the end of time.
+    """
+    timeRange: FilterTimeRangeInput
     """
     If provided, specifies case-insensitive filters that work against the [tag]({{Types.Track}}) of a track
     """

--- a/graphql/api/filter.graphqls
+++ b/graphql/api/filter.graphqls
@@ -176,6 +176,71 @@ input FilterDateTimeOffsetInput {
 }
 
 """
+`TimeRangeInput` describes a period of time as a closed interval. Either bound may be omitted to leave that
+side of the interval unbounded — a null `start` means "since the beginning of time" and a null `end` means
+"until the end of time".
+"""
+input TimeRangeInput {
+    """
+    The inclusive start of the period. If omitted or null, the period is unbounded in the past.
+    """
+    start: DateTimeOffset
+    """
+    The inclusive end of the period. If omitted or null, the period is unbounded in the future.
+    """
+    end: DateTimeOffset
+}
+
+"""
+`FilterTimeRangeInput` allows for filtering time-bounded objects — those that span a period rather than
+occurring at an instant — by the relationship between the object's own period and a given period. Exactly
+one field must be provided per filter object.
+
+An object whose period has not ended yet is treated as running until the end of time, which is why
+`endingWithin` and `before` never match one.
+"""
+input FilterTimeRangeInput @oneOf {
+    """
+    If provided, the object's period must fully contain the given period to match the filter.
+    """
+    containing: TimeRangeInput
+    """
+    If provided, the object's period must fall entirely inside the given period to match the filter.
+    An object that has not ended matches only when the given period is itself unbounded in the future.
+    """
+    containedBy: TimeRangeInput
+    """
+    If provided, the object's period must overlap the given period to match the filter. Periods that
+    merely touch at an endpoint do overlap.
+    """
+    intersecting: TimeRangeInput
+    """
+    If provided, the start of the object's period must fall within the given period to match the filter.
+    The object's end is ignored, so objects that have not ended are matched on equal footing.
+    """
+    startingWithin: TimeRangeInput
+    """
+    If provided, the end of the object's period must fall within the given period to match the filter.
+    An object that has not ended never matches.
+    """
+    endingWithin: TimeRangeInput
+    """
+    If provided, the object's period must include the given instant to match the filter. An object whose
+    period starts or ends exactly at the instant does include it.
+    """
+    containingInstant: DateTimeOffset
+    """
+    If provided, the object's period must have ended before the given instant to match the filter.
+    An object that has not ended never matches.
+    """
+    before: DateTimeOffset
+    """
+    If provided, the object's period must start after the given instant to match the filter.
+    """
+    after: DateTimeOffset
+}
+
+"""
 `FilterBooleanInput` allows for filtering based on a Boolean parameter. Only one field should be provided per filter object.
 """
 input FilterBooleanInput {

--- a/java/src/main/java/io/worlds/api/model/FilterActivityChronicleInput.java
+++ b/java/src/main/java/io/worlds/api/model/FilterActivityChronicleInput.java
@@ -15,6 +15,7 @@ public class FilterActivityChronicleInput implements java.io.Serializable {
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> description = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> startTime = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> endTime = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<FilterTimeRangeInput> timeRange = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> timezone = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> priority = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> status = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -34,12 +35,13 @@ public class FilterActivityChronicleInput implements java.io.Serializable {
     public FilterActivityChronicleInput() {
     }
 
-    public FilterActivityChronicleInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterStringInput> name, org.springframework.graphql.data.ArgumentValue<FilterStringInput> description, org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> startTime, org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> endTime, org.springframework.graphql.data.ArgumentValue<FilterStringInput> timezone, org.springframework.graphql.data.ArgumentValue<FilterStringInput> priority, org.springframework.graphql.data.ArgumentValue<FilterStringInput> status, org.springframework.graphql.data.ArgumentValue<FilterChronicleValidationStatusInput> validation, org.springframework.graphql.data.ArgumentValue<FilterPointInput> position, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> labels, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> locations, org.springframework.graphql.data.ArgumentValue<FilterIDInput> chronicleProducerId, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> tagIds, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> siteIds, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> dataSourceIds, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> pointOfInterestIds, java.util.List<FilterActivityChronicleInput> and, java.util.List<FilterActivityChronicleInput> or, org.springframework.graphql.data.ArgumentValue<FilterActivityChronicleInput> not) {
+    public FilterActivityChronicleInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterStringInput> name, org.springframework.graphql.data.ArgumentValue<FilterStringInput> description, org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> startTime, org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> endTime, org.springframework.graphql.data.ArgumentValue<FilterTimeRangeInput> timeRange, org.springframework.graphql.data.ArgumentValue<FilterStringInput> timezone, org.springframework.graphql.data.ArgumentValue<FilterStringInput> priority, org.springframework.graphql.data.ArgumentValue<FilterStringInput> status, org.springframework.graphql.data.ArgumentValue<FilterChronicleValidationStatusInput> validation, org.springframework.graphql.data.ArgumentValue<FilterPointInput> position, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> labels, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> locations, org.springframework.graphql.data.ArgumentValue<FilterIDInput> chronicleProducerId, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> tagIds, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> siteIds, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> dataSourceIds, org.springframework.graphql.data.ArgumentValue<FilterIDListInput> pointOfInterestIds, java.util.List<FilterActivityChronicleInput> and, java.util.List<FilterActivityChronicleInput> or, org.springframework.graphql.data.ArgumentValue<FilterActivityChronicleInput> not) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.startTime = startTime;
         this.endTime = endTime;
+        this.timeRange = timeRange;
         this.timezone = timezone;
         this.priority = priority;
         this.status = status;
@@ -90,6 +92,13 @@ public class FilterActivityChronicleInput implements java.io.Serializable {
     }
     public void setEndTime(org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> endTime) {
         this.endTime = endTime;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<FilterTimeRangeInput> getTimeRange() {
+        return timeRange;
+    }
+    public void setTimeRange(org.springframework.graphql.data.ArgumentValue<FilterTimeRangeInput> timeRange) {
+        this.timeRange = timeRange;
     }
 
     public org.springframework.graphql.data.ArgumentValue<FilterStringInput> getTimezone() {
@@ -211,6 +220,7 @@ public class FilterActivityChronicleInput implements java.io.Serializable {
             && Objects.equals(description, that.description)
             && Objects.equals(startTime, that.startTime)
             && Objects.equals(endTime, that.endTime)
+            && Objects.equals(timeRange, that.timeRange)
             && Objects.equals(timezone, that.timezone)
             && Objects.equals(priority, that.priority)
             && Objects.equals(status, that.status)
@@ -230,7 +240,7 @@ public class FilterActivityChronicleInput implements java.io.Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, startTime, endTime, timezone, priority, status, validation, position, labels, locations, chronicleProducerId, tagIds, siteIds, dataSourceIds, pointOfInterestIds, and, or, not);
+        return Objects.hash(id, name, description, startTime, endTime, timeRange, timezone, priority, status, validation, position, labels, locations, chronicleProducerId, tagIds, siteIds, dataSourceIds, pointOfInterestIds, and, or, not);
     }
 
 
@@ -245,6 +255,7 @@ public class FilterActivityChronicleInput implements java.io.Serializable {
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> description = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> startTime = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> endTime = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<FilterTimeRangeInput> timeRange = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> timezone = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> priority = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> status = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -286,6 +297,11 @@ public class FilterActivityChronicleInput implements java.io.Serializable {
 
         public Builder setEndTime(org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> endTime) {
             this.endTime = endTime;
+            return this;
+        }
+
+        public Builder setTimeRange(org.springframework.graphql.data.ArgumentValue<FilterTimeRangeInput> timeRange) {
+            this.timeRange = timeRange;
             return this;
         }
 
@@ -366,7 +382,7 @@ public class FilterActivityChronicleInput implements java.io.Serializable {
 
 
         public FilterActivityChronicleInput build() {
-            return new FilterActivityChronicleInput(id, name, description, startTime, endTime, timezone, priority, status, validation, position, labels, locations, chronicleProducerId, tagIds, siteIds, dataSourceIds, pointOfInterestIds, and, or, not);
+            return new FilterActivityChronicleInput(id, name, description, startTime, endTime, timeRange, timezone, priority, status, validation, position, labels, locations, chronicleProducerId, tagIds, siteIds, dataSourceIds, pointOfInterestIds, and, or, not);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/FilterTimeRangeInput.java
+++ b/java/src/main/java/io/worlds/api/model/FilterTimeRangeInput.java
@@ -1,0 +1,185 @@
+package io.worlds.api.model;
+
+import java.util.Objects;
+
+/**
+ * `FilterTimeRangeInput` allows for filtering time-bounded objects — those that span a period rather than
+occurring at an instant — by the relationship between the object's own period and a given period. Exactly
+one field must be provided per filter object.
+
+An object whose period has not ended yet is treated as running until the end of time, which is why
+`endingWithin` and `before` never match one.
+ */
+public class FilterTimeRangeInput implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private org.springframework.graphql.data.ArgumentValue<TimeRangeInput> containing = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<TimeRangeInput> containedBy = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<TimeRangeInput> intersecting = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<TimeRangeInput> startingWithin = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<TimeRangeInput> endingWithin = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> containingInstant = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> before = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> after = org.springframework.graphql.data.ArgumentValue.omitted();
+
+    public FilterTimeRangeInput() {
+    }
+
+    public FilterTimeRangeInput(org.springframework.graphql.data.ArgumentValue<TimeRangeInput> containing, org.springframework.graphql.data.ArgumentValue<TimeRangeInput> containedBy, org.springframework.graphql.data.ArgumentValue<TimeRangeInput> intersecting, org.springframework.graphql.data.ArgumentValue<TimeRangeInput> startingWithin, org.springframework.graphql.data.ArgumentValue<TimeRangeInput> endingWithin, org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> containingInstant, org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> before, org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> after) {
+        this.containing = containing;
+        this.containedBy = containedBy;
+        this.intersecting = intersecting;
+        this.startingWithin = startingWithin;
+        this.endingWithin = endingWithin;
+        this.containingInstant = containingInstant;
+        this.before = before;
+        this.after = after;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<TimeRangeInput> getContaining() {
+        return containing;
+    }
+    public void setContaining(org.springframework.graphql.data.ArgumentValue<TimeRangeInput> containing) {
+        this.containing = containing;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<TimeRangeInput> getContainedBy() {
+        return containedBy;
+    }
+    public void setContainedBy(org.springframework.graphql.data.ArgumentValue<TimeRangeInput> containedBy) {
+        this.containedBy = containedBy;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<TimeRangeInput> getIntersecting() {
+        return intersecting;
+    }
+    public void setIntersecting(org.springframework.graphql.data.ArgumentValue<TimeRangeInput> intersecting) {
+        this.intersecting = intersecting;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<TimeRangeInput> getStartingWithin() {
+        return startingWithin;
+    }
+    public void setStartingWithin(org.springframework.graphql.data.ArgumentValue<TimeRangeInput> startingWithin) {
+        this.startingWithin = startingWithin;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<TimeRangeInput> getEndingWithin() {
+        return endingWithin;
+    }
+    public void setEndingWithin(org.springframework.graphql.data.ArgumentValue<TimeRangeInput> endingWithin) {
+        this.endingWithin = endingWithin;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> getContainingInstant() {
+        return containingInstant;
+    }
+    public void setContainingInstant(org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> containingInstant) {
+        this.containingInstant = containingInstant;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> getBefore() {
+        return before;
+    }
+    public void setBefore(org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> before) {
+        this.before = before;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> getAfter() {
+        return after;
+    }
+    public void setAfter(org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> after) {
+        this.after = after;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final FilterTimeRangeInput that = (FilterTimeRangeInput) obj;
+        return Objects.equals(containing, that.containing)
+            && Objects.equals(containedBy, that.containedBy)
+            && Objects.equals(intersecting, that.intersecting)
+            && Objects.equals(startingWithin, that.startingWithin)
+            && Objects.equals(endingWithin, that.endingWithin)
+            && Objects.equals(containingInstant, that.containingInstant)
+            && Objects.equals(before, that.before)
+            && Objects.equals(after, that.after);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(containing, containedBy, intersecting, startingWithin, endingWithin, containingInstant, before, after);
+    }
+
+
+    public static FilterTimeRangeInput.Builder builder() {
+        return new FilterTimeRangeInput.Builder();
+    }
+
+    public static class Builder {
+
+        private org.springframework.graphql.data.ArgumentValue<TimeRangeInput> containing = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<TimeRangeInput> containedBy = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<TimeRangeInput> intersecting = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<TimeRangeInput> startingWithin = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<TimeRangeInput> endingWithin = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> containingInstant = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> before = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> after = org.springframework.graphql.data.ArgumentValue.omitted();
+
+        public Builder() {
+        }
+
+        public Builder setContaining(org.springframework.graphql.data.ArgumentValue<TimeRangeInput> containing) {
+            this.containing = containing;
+            return this;
+        }
+
+        public Builder setContainedBy(org.springframework.graphql.data.ArgumentValue<TimeRangeInput> containedBy) {
+            this.containedBy = containedBy;
+            return this;
+        }
+
+        public Builder setIntersecting(org.springframework.graphql.data.ArgumentValue<TimeRangeInput> intersecting) {
+            this.intersecting = intersecting;
+            return this;
+        }
+
+        public Builder setStartingWithin(org.springframework.graphql.data.ArgumentValue<TimeRangeInput> startingWithin) {
+            this.startingWithin = startingWithin;
+            return this;
+        }
+
+        public Builder setEndingWithin(org.springframework.graphql.data.ArgumentValue<TimeRangeInput> endingWithin) {
+            this.endingWithin = endingWithin;
+            return this;
+        }
+
+        public Builder setContainingInstant(org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> containingInstant) {
+            this.containingInstant = containingInstant;
+            return this;
+        }
+
+        public Builder setBefore(org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> before) {
+            this.before = before;
+            return this;
+        }
+
+        public Builder setAfter(org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> after) {
+            this.after = after;
+            return this;
+        }
+
+
+        public FilterTimeRangeInput build() {
+            return new FilterTimeRangeInput(containing, containedBy, intersecting, startingWithin, endingWithin, containingInstant, before, after);
+        }
+
+    }
+}

--- a/java/src/main/java/io/worlds/api/model/FilterTrackInput.java
+++ b/java/src/main/java/io/worlds/api/model/FilterTrackInput.java
@@ -12,8 +12,8 @@ public class FilterTrackInput implements java.io.Serializable {
 
     private org.springframework.graphql.data.ArgumentValue<FilterIDInput> id = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId = org.springframework.graphql.data.ArgumentValue.omitted();
-    @jakarta.validation.constraints.NotNull
-    private FilterDateTimeOffsetInput time;
+    private org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> time = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<FilterTimeRangeInput> timeRange = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> tag = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterPointInput> position = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -31,10 +31,11 @@ public class FilterTrackInput implements java.io.Serializable {
     public FilterTrackInput() {
     }
 
-    public FilterTrackInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId, FilterDateTimeOffsetInput time, org.springframework.graphql.data.ArgumentValue<FilterStringInput> tag, org.springframework.graphql.data.ArgumentValue<FilterPointInput> position, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute, org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId, org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels, java.util.List<FilterTrackInput> and, java.util.List<FilterTrackInput> or, org.springframework.graphql.data.ArgumentValue<FilterTrackInput> not, org.springframework.graphql.data.ArgumentValue<FilterIDInput> deviceId) {
+    public FilterTrackInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId, org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> time, org.springframework.graphql.data.ArgumentValue<FilterTimeRangeInput> timeRange, org.springframework.graphql.data.ArgumentValue<FilterStringInput> tag, org.springframework.graphql.data.ArgumentValue<FilterPointInput> position, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute, org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId, org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels, java.util.List<FilterTrackInput> and, java.util.List<FilterTrackInput> or, org.springframework.graphql.data.ArgumentValue<FilterTrackInput> not, org.springframework.graphql.data.ArgumentValue<FilterIDInput> deviceId) {
         this.id = id;
         this.dataSourceId = dataSourceId;
         this.time = time;
+        this.timeRange = timeRange;
         this.tag = tag;
         this.position = position;
         this.identifier = identifier;
@@ -63,11 +64,18 @@ public class FilterTrackInput implements java.io.Serializable {
         this.dataSourceId = dataSourceId;
     }
 
-    public FilterDateTimeOffsetInput getTime() {
+    public org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> getTime() {
         return time;
     }
-    public void setTime(FilterDateTimeOffsetInput time) {
+    public void setTime(org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> time) {
         this.time = time;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<FilterTimeRangeInput> getTimeRange() {
+        return timeRange;
+    }
+    public void setTimeRange(org.springframework.graphql.data.ArgumentValue<FilterTimeRangeInput> timeRange) {
+        this.timeRange = timeRange;
     }
 
     public org.springframework.graphql.data.ArgumentValue<FilterStringInput> getTag() {
@@ -168,6 +176,7 @@ public class FilterTrackInput implements java.io.Serializable {
         return Objects.equals(id, that.id)
             && Objects.equals(dataSourceId, that.dataSourceId)
             && Objects.equals(time, that.time)
+            && Objects.equals(timeRange, that.timeRange)
             && Objects.equals(tag, that.tag)
             && Objects.equals(position, that.position)
             && Objects.equals(identifier, that.identifier)
@@ -184,7 +193,7 @@ public class FilterTrackInput implements java.io.Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, dataSourceId, time, tag, position, identifier, attribute, pointOfInterestId, siteId, dataSourceType, dataSourceLabels, and, or, not, deviceId);
+        return Objects.hash(id, dataSourceId, time, timeRange, tag, position, identifier, attribute, pointOfInterestId, siteId, dataSourceType, dataSourceLabels, and, or, not, deviceId);
     }
 
 
@@ -196,7 +205,8 @@ public class FilterTrackInput implements java.io.Serializable {
 
         private org.springframework.graphql.data.ArgumentValue<FilterIDInput> id = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId = org.springframework.graphql.data.ArgumentValue.omitted();
-        private FilterDateTimeOffsetInput time;
+        private org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> time = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<FilterTimeRangeInput> timeRange = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> tag = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterPointInput> position = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -223,8 +233,13 @@ public class FilterTrackInput implements java.io.Serializable {
             return this;
         }
 
-        public Builder setTime(FilterDateTimeOffsetInput time) {
+        public Builder setTime(org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> time) {
             this.time = time;
+            return this;
+        }
+
+        public Builder setTimeRange(org.springframework.graphql.data.ArgumentValue<FilterTimeRangeInput> timeRange) {
+            this.timeRange = timeRange;
             return this;
         }
 
@@ -291,7 +306,7 @@ public class FilterTrackInput implements java.io.Serializable {
 
 
         public FilterTrackInput build() {
-            return new FilterTrackInput(id, dataSourceId, time, tag, position, identifier, attribute, pointOfInterestId, siteId, dataSourceType, dataSourceLabels, and, or, not, deviceId);
+            return new FilterTrackInput(id, dataSourceId, time, timeRange, tag, position, identifier, attribute, pointOfInterestId, siteId, dataSourceType, dataSourceLabels, and, or, not, deviceId);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/TimeRangeInput.java
+++ b/java/src/main/java/io/worlds/api/model/TimeRangeInput.java
@@ -1,0 +1,86 @@
+package io.worlds.api.model;
+
+import java.util.Objects;
+
+/**
+ * `TimeRangeInput` describes a period of time as a closed interval. Either bound may be omitted to leave that
+side of the interval unbounded — a null `start` means "since the beginning of time" and a null `end` means
+"until the end of time".
+ */
+public class TimeRangeInput implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> start = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> end = org.springframework.graphql.data.ArgumentValue.omitted();
+
+    public TimeRangeInput() {
+    }
+
+    public TimeRangeInput(org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> start, org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> getStart() {
+        return start;
+    }
+    public void setStart(org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> start) {
+        this.start = start;
+    }
+
+    public org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> getEnd() {
+        return end;
+    }
+    public void setEnd(org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> end) {
+        this.end = end;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final TimeRangeInput that = (TimeRangeInput) obj;
+        return Objects.equals(start, that.start)
+            && Objects.equals(end, that.end);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(start, end);
+    }
+
+
+    public static TimeRangeInput.Builder builder() {
+        return new TimeRangeInput.Builder();
+    }
+
+    public static class Builder {
+
+        private org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> start = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> end = org.springframework.graphql.data.ArgumentValue.omitted();
+
+        public Builder() {
+        }
+
+        public Builder setStart(org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> start) {
+            this.start = start;
+            return this;
+        }
+
+        public Builder setEnd(org.springframework.graphql.data.ArgumentValue<java.time.OffsetDateTime> end) {
+            this.end = end;
+            return this;
+        }
+
+
+        public TimeRangeInput build() {
+            return new TimeRangeInput(start, end);
+        }
+
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TimeRangeInput`, a closed interval with optional bounds, and `FilterTimeRangeInput`, a `@oneOf` filter with eight predicates for filtering objects that span a period rather than occur at an instant.
- Wire `timeRange` onto `FilterTrackInput` and `FilterActivityChronicleInput`.
- Relax `FilterTrackInput.time` to nullable so `timeRange` can be used on its own. The non-null was a performance guard from when global tracks were time partitioned; `track` is a plain table now.

## Test plan
- [x] Schema builds and generated model classes compile.
- [x] `time` omitted with only `timeRange` provided is accepted by the schema.
- [x] `FilterTimeRangeInput` rejects more than one predicate per object (`@oneOf`).
- [x] Existing clients passing `time` are unaffected.

[CE-11399]

[CE-11399]: https://worlds-io.atlassian.net/browse/CE-11399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ