### PR TITLE
feat: CE-13586: Expose Track.modelId and add modelId track filter

### DIFF
--- a/graphql/api/domains/track/filter.graphqls
+++ b/graphql/api/domains/track/filter.graphqls
@@ -46,6 +46,10 @@ input FilterTrackInput {
     """
     siteId: FilterIDInput
     """
+    If provided, specifies filters that work against the [unique identifier of the model]({{Types.Track}}) that produced the track.
+    """
+    modelId: FilterIDInput
+    """
     If provided, specifies filters that work against the `type` of the track's [`dataSource`]({{Types.DataSource}}).
     """
     dataSourceType: FilterStringInput
@@ -108,6 +112,10 @@ input FilterTrackMessageInput {
     If provided, specifies filters that work against the [unique identifier of the site]({{Types.Site}}) that the track's data source belongs to.
     """
     siteId: FilterIDInput
+    """
+    If provided, specifies filters that work against the [unique identifier of the model]({{Types.Track}}) that produced the track.
+    """
+    modelId: FilterIDInput
     """
     If provided, specifies filters that work against the `type` of the track's [`dataSource`]({{Types.DataSource}}).
     """

--- a/graphql/api/domains/track/track.graphqls
+++ b/graphql/api/domains/track/track.graphqls
@@ -5,6 +5,8 @@ type Track {
     dataSource: DataSource
     """The video that this detection was captured in"""
     video: Video
+    """The unique identifier of the model that produced the Track."""
+    modelId: ID
     """The class label of the tracked object, i.e person, car, truck, etc."""
     tag: String!
     """The time of the first detection of the tracked object."""

--- a/java/src/main/java/io/worlds/api/model/FilterTrackInput.java
+++ b/java/src/main/java/io/worlds/api/model/FilterTrackInput.java
@@ -20,6 +20,7 @@ public class FilterTrackInput implements java.io.Serializable {
     private org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<FilterIDInput> modelId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels = org.springframework.graphql.data.ArgumentValue.omitted();
     private java.util.List<FilterTrackInput> and;
@@ -31,7 +32,7 @@ public class FilterTrackInput implements java.io.Serializable {
     public FilterTrackInput() {
     }
 
-    public FilterTrackInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId, org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> time, org.springframework.graphql.data.ArgumentValue<FilterTimeRangeInput> timeRange, org.springframework.graphql.data.ArgumentValue<FilterStringInput> tag, org.springframework.graphql.data.ArgumentValue<FilterPointInput> position, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute, org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId, org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels, java.util.List<FilterTrackInput> and, java.util.List<FilterTrackInput> or, org.springframework.graphql.data.ArgumentValue<FilterTrackInput> not, org.springframework.graphql.data.ArgumentValue<FilterIDInput> deviceId) {
+    public FilterTrackInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId, org.springframework.graphql.data.ArgumentValue<FilterDateTimeOffsetInput> time, org.springframework.graphql.data.ArgumentValue<FilterTimeRangeInput> timeRange, org.springframework.graphql.data.ArgumentValue<FilterStringInput> tag, org.springframework.graphql.data.ArgumentValue<FilterPointInput> position, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute, org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId, org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId, org.springframework.graphql.data.ArgumentValue<FilterIDInput> modelId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels, java.util.List<FilterTrackInput> and, java.util.List<FilterTrackInput> or, org.springframework.graphql.data.ArgumentValue<FilterTrackInput> not, org.springframework.graphql.data.ArgumentValue<FilterIDInput> deviceId) {
         this.id = id;
         this.dataSourceId = dataSourceId;
         this.time = time;
@@ -42,6 +43,7 @@ public class FilterTrackInput implements java.io.Serializable {
         this.attribute = attribute;
         this.pointOfInterestId = pointOfInterestId;
         this.siteId = siteId;
+        this.modelId = modelId;
         this.dataSourceType = dataSourceType;
         this.dataSourceLabels = dataSourceLabels;
         this.and = and;
@@ -120,6 +122,13 @@ public class FilterTrackInput implements java.io.Serializable {
         this.siteId = siteId;
     }
 
+    public org.springframework.graphql.data.ArgumentValue<FilterIDInput> getModelId() {
+        return modelId;
+    }
+    public void setModelId(org.springframework.graphql.data.ArgumentValue<FilterIDInput> modelId) {
+        this.modelId = modelId;
+    }
+
     public org.springframework.graphql.data.ArgumentValue<FilterStringInput> getDataSourceType() {
         return dataSourceType;
     }
@@ -183,6 +192,7 @@ public class FilterTrackInput implements java.io.Serializable {
             && Objects.equals(attribute, that.attribute)
             && Objects.equals(pointOfInterestId, that.pointOfInterestId)
             && Objects.equals(siteId, that.siteId)
+            && Objects.equals(modelId, that.modelId)
             && Objects.equals(dataSourceType, that.dataSourceType)
             && Objects.equals(dataSourceLabels, that.dataSourceLabels)
             && Objects.equals(and, that.and)
@@ -193,7 +203,7 @@ public class FilterTrackInput implements java.io.Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, dataSourceId, time, timeRange, tag, position, identifier, attribute, pointOfInterestId, siteId, dataSourceType, dataSourceLabels, and, or, not, deviceId);
+        return Objects.hash(id, dataSourceId, time, timeRange, tag, position, identifier, attribute, pointOfInterestId, siteId, modelId, dataSourceType, dataSourceLabels, and, or, not, deviceId);
     }
 
 
@@ -213,6 +223,7 @@ public class FilterTrackInput implements java.io.Serializable {
         private org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<FilterIDInput> modelId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels = org.springframework.graphql.data.ArgumentValue.omitted();
         private java.util.List<FilterTrackInput> and;
@@ -273,6 +284,11 @@ public class FilterTrackInput implements java.io.Serializable {
             return this;
         }
 
+        public Builder setModelId(org.springframework.graphql.data.ArgumentValue<FilterIDInput> modelId) {
+            this.modelId = modelId;
+            return this;
+        }
+
         public Builder setDataSourceType(org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType) {
             this.dataSourceType = dataSourceType;
             return this;
@@ -306,7 +322,7 @@ public class FilterTrackInput implements java.io.Serializable {
 
 
         public FilterTrackInput build() {
-            return new FilterTrackInput(id, dataSourceId, time, timeRange, tag, position, identifier, attribute, pointOfInterestId, siteId, dataSourceType, dataSourceLabels, and, or, not, deviceId);
+            return new FilterTrackInput(id, dataSourceId, time, timeRange, tag, position, identifier, attribute, pointOfInterestId, siteId, modelId, dataSourceType, dataSourceLabels, and, or, not, deviceId);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/FilterTrackMessageInput.java
+++ b/java/src/main/java/io/worlds/api/model/FilterTrackMessageInput.java
@@ -18,6 +18,7 @@ public class FilterTrackMessageInput implements java.io.Serializable {
     private org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId = org.springframework.graphql.data.ArgumentValue.omitted();
+    private org.springframework.graphql.data.ArgumentValue<FilterIDInput> modelId = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels = org.springframework.graphql.data.ArgumentValue.omitted();
     private org.springframework.graphql.data.ArgumentValue<FilterMessageStateInput> state = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -28,7 +29,7 @@ public class FilterTrackMessageInput implements java.io.Serializable {
     public FilterTrackMessageInput() {
     }
 
-    public FilterTrackMessageInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> tag, org.springframework.graphql.data.ArgumentValue<FilterPointInput> position, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute, org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId, org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels, org.springframework.graphql.data.ArgumentValue<FilterMessageStateInput> state, java.util.List<FilterTrackMessageInput> and, java.util.List<FilterTrackMessageInput> or, org.springframework.graphql.data.ArgumentValue<FilterTrackMessageInput> not) {
+    public FilterTrackMessageInput(org.springframework.graphql.data.ArgumentValue<FilterIDInput> id, org.springframework.graphql.data.ArgumentValue<FilterIDInput> dataSourceId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> tag, org.springframework.graphql.data.ArgumentValue<FilterPointInput> position, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> identifier, org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute, org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId, org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId, org.springframework.graphql.data.ArgumentValue<FilterIDInput> modelId, org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType, org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels, org.springframework.graphql.data.ArgumentValue<FilterMessageStateInput> state, java.util.List<FilterTrackMessageInput> and, java.util.List<FilterTrackMessageInput> or, org.springframework.graphql.data.ArgumentValue<FilterTrackMessageInput> not) {
         this.id = id;
         this.dataSourceId = dataSourceId;
         this.tag = tag;
@@ -37,6 +38,7 @@ public class FilterTrackMessageInput implements java.io.Serializable {
         this.attribute = attribute;
         this.pointOfInterestId = pointOfInterestId;
         this.siteId = siteId;
+        this.modelId = modelId;
         this.dataSourceType = dataSourceType;
         this.dataSourceLabels = dataSourceLabels;
         this.state = state;
@@ -101,6 +103,13 @@ public class FilterTrackMessageInput implements java.io.Serializable {
         this.siteId = siteId;
     }
 
+    public org.springframework.graphql.data.ArgumentValue<FilterIDInput> getModelId() {
+        return modelId;
+    }
+    public void setModelId(org.springframework.graphql.data.ArgumentValue<FilterIDInput> modelId) {
+        this.modelId = modelId;
+    }
+
     public org.springframework.graphql.data.ArgumentValue<FilterStringInput> getDataSourceType() {
         return dataSourceType;
     }
@@ -160,6 +169,7 @@ public class FilterTrackMessageInput implements java.io.Serializable {
             && Objects.equals(attribute, that.attribute)
             && Objects.equals(pointOfInterestId, that.pointOfInterestId)
             && Objects.equals(siteId, that.siteId)
+            && Objects.equals(modelId, that.modelId)
             && Objects.equals(dataSourceType, that.dataSourceType)
             && Objects.equals(dataSourceLabels, that.dataSourceLabels)
             && Objects.equals(state, that.state)
@@ -170,7 +180,7 @@ public class FilterTrackMessageInput implements java.io.Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, dataSourceId, tag, position, identifier, attribute, pointOfInterestId, siteId, dataSourceType, dataSourceLabels, state, and, or, not);
+        return Objects.hash(id, dataSourceId, tag, position, identifier, attribute, pointOfInterestId, siteId, modelId, dataSourceType, dataSourceLabels, state, and, or, not);
     }
 
 
@@ -188,6 +198,7 @@ public class FilterTrackMessageInput implements java.io.Serializable {
         private org.springframework.graphql.data.ArgumentValue<FilterTrackPropertyInput> attribute = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterIDInput> pointOfInterestId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterIDInput> siteId = org.springframework.graphql.data.ArgumentValue.omitted();
+        private org.springframework.graphql.data.ArgumentValue<FilterIDInput> modelId = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterStringListInput> dataSourceLabels = org.springframework.graphql.data.ArgumentValue.omitted();
         private org.springframework.graphql.data.ArgumentValue<FilterMessageStateInput> state = org.springframework.graphql.data.ArgumentValue.omitted();
@@ -238,6 +249,11 @@ public class FilterTrackMessageInput implements java.io.Serializable {
             return this;
         }
 
+        public Builder setModelId(org.springframework.graphql.data.ArgumentValue<FilterIDInput> modelId) {
+            this.modelId = modelId;
+            return this;
+        }
+
         public Builder setDataSourceType(org.springframework.graphql.data.ArgumentValue<FilterStringInput> dataSourceType) {
             this.dataSourceType = dataSourceType;
             return this;
@@ -270,7 +286,7 @@ public class FilterTrackMessageInput implements java.io.Serializable {
 
 
         public FilterTrackMessageInput build() {
-            return new FilterTrackMessageInput(id, dataSourceId, tag, position, identifier, attribute, pointOfInterestId, siteId, dataSourceType, dataSourceLabels, state, and, or, not);
+            return new FilterTrackMessageInput(id, dataSourceId, tag, position, identifier, attribute, pointOfInterestId, siteId, modelId, dataSourceType, dataSourceLabels, state, and, or, not);
         }
 
     }

--- a/java/src/main/java/io/worlds/api/model/Track.java
+++ b/java/src/main/java/io/worlds/api/model/Track.java
@@ -10,6 +10,7 @@ public class Track implements java.io.Serializable {
     private String id;
     private DataSource dataSource;
     private Video video;
+    private String modelId;
     @jakarta.validation.constraints.NotNull
     private String tag;
     @jakarta.validation.constraints.NotNull
@@ -27,10 +28,11 @@ public class Track implements java.io.Serializable {
     public Track() {
     }
 
-    public Track(String id, DataSource dataSource, Video video, String tag, java.time.OffsetDateTime startTime, java.time.OffsetDateTime endTime, java.util.List<Detection> detections, TrackProperties properties, java.lang.Object metadata, java.util.List<ZoneIntersection> zoneIntersections, java.util.List<GeofenceIntersection> geofenceIntersections, java.util.List<String> deviceIds) {
+    public Track(String id, DataSource dataSource, Video video, String modelId, String tag, java.time.OffsetDateTime startTime, java.time.OffsetDateTime endTime, java.util.List<Detection> detections, TrackProperties properties, java.lang.Object metadata, java.util.List<ZoneIntersection> zoneIntersections, java.util.List<GeofenceIntersection> geofenceIntersections, java.util.List<String> deviceIds) {
         this.id = id;
         this.dataSource = dataSource;
         this.video = video;
+        this.modelId = modelId;
         this.tag = tag;
         this.startTime = startTime;
         this.endTime = endTime;
@@ -79,6 +81,19 @@ public class Track implements java.io.Serializable {
      */
     public void setVideo(Video video) {
         this.video = video;
+    }
+
+    /**
+     * The unique identifier of the model that produced the Track.
+     */
+    public String getModelId() {
+        return modelId;
+    }
+    /**
+     * The unique identifier of the model that produced the Track.
+     */
+    public void setModelId(String modelId) {
+        this.modelId = modelId;
     }
 
     /**
@@ -212,6 +227,7 @@ public class Track implements java.io.Serializable {
         return Objects.equals(id, that.id)
             && Objects.equals(dataSource, that.dataSource)
             && Objects.equals(video, that.video)
+            && Objects.equals(modelId, that.modelId)
             && Objects.equals(tag, that.tag)
             && Objects.equals(startTime, that.startTime)
             && Objects.equals(endTime, that.endTime)
@@ -225,7 +241,7 @@ public class Track implements java.io.Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, dataSource, video, tag, startTime, endTime, detections, properties, metadata, zoneIntersections, geofenceIntersections, deviceIds);
+        return Objects.hash(id, dataSource, video, modelId, tag, startTime, endTime, detections, properties, metadata, zoneIntersections, geofenceIntersections, deviceIds);
     }
 
 
@@ -238,6 +254,7 @@ public class Track implements java.io.Serializable {
         private String id;
         private DataSource dataSource;
         private Video video;
+        private String modelId;
         private String tag;
         private java.time.OffsetDateTime startTime;
         private java.time.OffsetDateTime endTime;
@@ -272,6 +289,14 @@ public class Track implements java.io.Serializable {
          */
         public Builder setVideo(Video video) {
             this.video = video;
+            return this;
+        }
+
+        /**
+         * The unique identifier of the model that produced the Track.
+         */
+        public Builder setModelId(String modelId) {
+            this.modelId = modelId;
             return this;
         }
 
@@ -350,7 +375,7 @@ public class Track implements java.io.Serializable {
 
 
         public Track build() {
-            return new Track(id, dataSource, video, tag, startTime, endTime, detections, properties, metadata, zoneIntersections, geofenceIntersections, deviceIds);
+            return new Track(id, dataSource, video, modelId, tag, startTime, endTime, detections, properties, metadata, zoneIntersections, geofenceIntersections, deviceIds);
         }
 
     }


### PR DESCRIPTION
## Summary
- Expose the track `model_id` column on the GraphQL `Track` type as `modelId: ID` (nullable — a non-null addition would break existing clients, and older tracks have no model).
- Add `modelId: FilterIDInput` to `FilterTrackInput` and `FilterTrackMessageInput` so both the `tracks` query and the `tracks` subscription can be scoped to a single model, mirroring the `siteId` change in CE-11611.

[CE-13586]

[CE-13586]: https://worlds-io.atlassian.net/browse/CE-13586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ